### PR TITLE
fix: improper handling of application/x-www-form-urlencoded

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -27,6 +27,7 @@ describe('construct request', () => {
               { name: 'b', value: 2 },
             ],
             postData: {
+              mimeType: 'application/json',
               text: '{"id":8,"category":{"id":6,"name":"name"},"name":"name"}',
             },
             method: 'PUT',
@@ -52,6 +53,51 @@ describe('construct request', () => {
 
     expect(request.headers.get('user-agent')).toBe('test-user-agent/1.0');
   });
+
+  it('should be able to handle application/x-www-form-urlencoded payloads', () => {
+    const harWithPostDataParams = {
+      log: {
+        entries: [
+          {
+            request: {
+              headers: [
+                {
+                  name: 'Authorization',
+                  value: 'Bearer api-key',
+                },
+                {
+                  name: 'Content-Type',
+                  value: 'application/json',
+                },
+              ],
+              queryString: [
+                { name: 'a', value: 1 },
+                { name: 'b', value: 2 },
+              ],
+              postData: {
+                mimeType: 'application/x-www-form-urlencoded',
+                params: [
+                  { name: 'id', value: 8 },
+                  { name: 'category', value: JSON.stringify({ id: 6, name: 'name' }) },
+                  { name: 'name', value: 'name' },
+                ],
+              },
+              method: 'PUT',
+              url: 'http://petstore.swagger.io/v2/pet',
+            },
+          },
+        ],
+      },
+    };
+
+    const request = constructRequest(harWithPostDataParams);
+
+    expect(request.url).toBe('http://petstore.swagger.io/v2/pet?a=1&b=2');
+    expect(request.method).toBe('PUT');
+    expect(request.headers.get('authorization')).toBe('Bearer api-key');
+    expect(request.headers.get('content-type')).toBe('application/json');
+    expect(request.body.toString()).toBe('{"id":8,"category":{"id":6,"name":"name"},"name":"name"}');
+  });
 });
 
 describe('fetch har', () => {
@@ -74,7 +120,7 @@ describe('fetch har', () => {
   };
 
   it('should throw if it looks like you are missing a valid har file', () => {
-    expect(fetchHar).toThrow('Missing har file');
+    expect(fetchHar).toThrow('Missing HAR file');
     expect(fetchHar.bind(null, { log: {} })).toThrow('Missing log.entries array');
     expect(fetchHar.bind(null, { log: { entries: [] } })).toThrow('Missing log.entries array');
   });


### PR DESCRIPTION
As discovered with https://github.com/readmeio/api-explorer/pull/807, the HAR definitions that we're building with [@readme/oas-to-har](https://www.npmjs.com/package/@readme/oas-to-har) don't properly handle `application/x-www-form-urlencoded` content types. 

I've fixed some bugs in that library to properly store payloads from `application/x-www-form-urlencoded` requests into `postData.params` (along with a few other issues that caused HAR files generated from it to not validate), but this library didn't have any support for `postData.params`, or when `postData` is not present like in the case of a simple GET request.