### PR TITLE
fix: improved handling of application/x-www-form-urlencoded postData

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -95,8 +95,12 @@ describe('construct request', () => {
     expect(request.url).toBe('http://petstore.swagger.io/v2/pet?a=1&b=2');
     expect(request.method).toBe('PUT');
     expect(request.headers.get('authorization')).toBe('Bearer api-key');
-    expect(request.headers.get('content-type')).toBe('application/json');
-    expect(request.body.toString()).toBe('{"id":8,"category":{"id":6,"name":"name"},"name":"name"}');
+
+    // Though we have a Content-Type header set to application/json, since the post data is to be
+    // treated as application/x-www-form-urlencoded, that needs to be the only Content-Type header
+    // present. This is how Postman handles this case!
+    expect(request.headers.get('content-type')).toBe('application/x-www-form-urlencoded');
+    expect(request.body.toString()).toBe('id=8&category=%7B%22id%22%3A6%2C%22name%22%3A%22name%22%7D&name=name');
   });
 });
 


### PR DESCRIPTION
This fixes some mishandling of `application/x-www-form-urlencoded` postData types introduced in https://github.com/readmeio/fetch-har/pull/67.

The problem that was introduced there was that `x-www-form-urlencoded` types would be encoded as JSON, not URLSearchParams, which resulted in payloads being improperly sent.

Here's an example before and after request:

#### Broken
![Screen Shot 2020-07-15 at 5 09 46 PM](https://user-images.githubusercontent.com/33762/87612018-50ce3a80-c6be-11ea-98ea-50c12f9e485e.png)

#### Fixed
![Screen Shot 2020-07-15 at 5 09 27 PM](https://user-images.githubusercontent.com/33762/87612022-53c92b00-c6be-11ea-8575-d7667a1c5512.png)

This also fixes an edge case where if a `Content-Type` header was set alongside `x-www-form-urlencoded` payloads, the payload would be set to the first `Content-Type` header instead of being overwritten as `x-www-form-urlencoded`. This is how Postman handles this edge case when building code snippets:

`Content-Type` set to `application/json`:

![Screen Shot 2020-07-15 at 5 13 59 PM](https://user-images.githubusercontent.com/33762/87612170-a86ca600-c6be-11ea-82d0-e94eeba9c2e1.png)

Payload defined as `x-www-form-urlencoded`:
![Screen Shot 2020-07-15 at 5 14 03 PM](https://user-images.githubusercontent.com/33762/87612174-ac002d00-c6be-11ea-9159-6e25011d1d57.png)

Resulting code snippet using `x-www-form-urlencoded`:

![Screen Shot 2020-07-15 at 5 14 25 PM](https://user-images.githubusercontent.com/33762/87612206-c1755700-c6be-11ea-8532-ee3eaa87c690.png)