### PR TITLE
fix: catch and toss errors from illegal header names in HARs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # fetch-har
 [![CI](https://github.com/readmeio/fetch-har/workflows/CI/badge.svg)](https://github.com/readmeio/fetch-har)
 
-Make a [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) request from a HAR file.
+Make a [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) request from a HAR definition.
 
 [![](https://d3vv6lp55qjaqc.cloudfront.net/items/1M3C3j0I0s0j3T362344/Untitled-2.png)](https://readme.io)
 
@@ -59,7 +59,7 @@ fetchHar(har)
 - `har` is a [har](https://en.wikipedia.org/wiki/.har) file format.
 - `userAgent` is an optional user agent string to let you declare where the request is coming from.
 
-Performs a fetch request from a given HAR file. HAR files can be used to list lots of requests but we only use the first from the `log.entries` array.
+Performs a fetch request from a given HAR definition. HAR definitions can be used to list lots of requests but we only use the first from the `log.entries` array.
 
 ### `fetchHar.constructRequest(har, userAgent) => Request`
 

--- a/__tests__/__fixtures__/invalid-headers.har.json
+++ b/__tests__/__fixtures__/invalid-headers.har.json
@@ -1,0 +1,35 @@
+{
+  "log": {
+    "entries": [
+      {
+        "startedDateTime": "2021-07-29T23:22:48.684Z",
+        "time": 88,
+        "request": {
+          "method": "POST",
+          "url": "https://httpbin.org/post",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-API-KEY",
+              "value": "asdf1234"
+            },
+            {
+              "name": "X-API-KEY (Invalid)",
+              "value": "1234asdf"
+            }
+          ],
+          "bodySize": -1,
+          "headersSize": -1
+        }
+      }
+    ]
+  }
+}

--- a/__tests__/browser.test.js
+++ b/__tests__/browser.test.js
@@ -2,12 +2,12 @@
 const fs = require('fs').promises;
 const path = require('path');
 const harExamples = require('har-examples');
-const jsonWithAuthHar = require('./__fixtures__/json-with-auth.har.json');
-const urlEncodedWithAuthHar = require('./__fixtures__/urlencoded-with-auth.har.json');
+const jsonWithAuthHAR = require('./__fixtures__/json-with-auth.har.json');
+const urlEncodedWithAuthHAR = require('./__fixtures__/urlencoded-with-auth.har.json');
 
 beforeAll(async () => {
   await page.exposeFunction('har_full', () => harExamples.full);
-  await page.exposeFunction('har_jsonWithAuthHar', () => jsonWithAuthHar);
+  await page.exposeFunction('har_jsonWithAuthHar', () => jsonWithAuthHAR);
   await page.exposeFunction('har_multipartData', () => harExamples['multipart-data']);
   await page.exposeFunction('har_multipartData_DataUrl', () => harExamples['multipart-data-dataurl']);
   await page.exposeFunction('har_multipartData_DataUrl_withParentheses', () => {
@@ -24,7 +24,7 @@ beforeAll(async () => {
   await page.exposeFunction('har_multipartFile', () => harExamples['multipart-file']);
   await page.exposeFunction('har_multipartFormData', () => harExamples['multipart-form-data']);
   await page.exposeFunction('har_textPlain', () => harExamples['text-plain']);
-  await page.exposeFunction('har_urlEncodedWithAuthHar', () => urlEncodedWithAuthHar);
+  await page.exposeFunction('har_urlEncodedWithAuthHar', () => urlEncodedWithAuthHAR);
 });
 
 beforeEach(async () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fetch-har",
   "version": "4.0.3",
-  "description": "Make a fetch request from a HAR file",
+  "description": "Make a fetch request from a HAR definition",
   "main": "index.js",
   "engines": {
     "node": "^12 || ^14 || ^16"


### PR DESCRIPTION
If a HAR has a header with an illegal name, like `X-API-KEY (Header)`, `Headers.append()` will throw an error. Instead of letting `fetch-har` fail on that we're going to instead catch and toss them.

![6e8b0704-c419-4cb4-8305-2718e74a5f49](https://user-images.githubusercontent.com/33762/127578966-1429a651-8a11-436b-a410-c9e91d0d40c6.png)
