### PR TITLE
fix: improper handling of query strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,8 +246,13 @@ function constructRequest(har, opts = { userAgent: false, files: {}, multipartEn
   }
 
   if ('queryString' in request && request.queryString.length) {
-    const query = request.queryString.map(q => `${q.name}=${q.value}`).join('&');
-    querystring = `?${query}`;
+    const queryParams = new URL(url).searchParams;
+
+    request.queryString.forEach(q => {
+      queryParams.append(q.name, q.value);
+    });
+
+    querystring = queryParams.toString();
   }
 
   if (opts.userAgent) {
@@ -256,7 +261,7 @@ function constructRequest(har, opts = { userAgent: false, files: {}, multipartEn
 
   options.headers = headers;
 
-  return new Request(`${url}${querystring}`, options);
+  return new Request(`${url.split('?')[0]}${querystring ? `?${querystring}` : ''}`, options);
 }
 
 function fetchHar(har, opts = { userAgent: false, files: {}, multipartEncoder: false }) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,7 +25,7 @@ describe('#fetch', function () {
     it('should convert a HAR object to a HTTP request object', async function () {
       const request = constructRequest(harExamples.full);
 
-      expect(request.url).to.equal('https://httpbin.org/post?key=value?foo=bar&foo=baz&baz=abc');
+      expect(request.url).to.equal('https://httpbin.org/post?key=value&foo=bar&foo=baz&baz=abc');
       expect(request.method).to.equal('POST');
 
       if (host.node) {
@@ -85,6 +85,13 @@ describe('#fetch', function () {
       expect(res.url).to.equal('https://httpbin.org/post');
     });
 
+    it('should support requests with array query parameters', async function () {
+      const res = await fetchHar(harExamples.query).then(r => r.json());
+
+      expect(res.args).to.deep.equal({ baz: 'abc', foo: ['bar', 'baz'], key: 'value' });
+      expect(res.url).to.equal('https://httpbin.org/get?key=value&foo=bar&foo=baz&baz=abc');
+    });
+
     it('should support requests with cookies', async function () {
       const res = await fetchHar(harExamples.cookies).then(r => r.json());
 
@@ -120,7 +127,7 @@ describe('#fetch', function () {
     it('should support requests that cover the entire HAR spec', async function () {
       const res = await fetchHar(harExamples.full).then(r => r.json());
 
-      expect(res.args).to.deep.equal({ baz: 'abc', foo: 'baz', key: 'value?foo=bar' });
+      expect(res.args).to.deep.equal({ baz: 'abc', foo: ['bar', 'baz'], key: 'value' });
       expect(res.data).to.equal('');
       expect(res.files).to.be.empty;
       expect(res.form).to.deep.equal({ foo: 'bar' });
@@ -133,7 +140,7 @@ describe('#fetch', function () {
       }
 
       expect(res.json).to.be.null;
-      expect(res.url).to.equal('https://httpbin.org/post?key=value%3Ffoo=bar&foo=baz&baz=abc');
+      expect(res.url).to.equal('https://httpbin.org/post?key=value&foo=bar&foo=baz&baz=abc');
     });
 
     describe('multipart/form-data', function () {


### PR DESCRIPTION
## 🧰 What's being changed?

While doing some cleanup in our [har-examples](https://npm.im/har-examples) I noticed that we had a query string example that had a query param defined in the URL instead of in `queryStrings`:

```json
{
  "log": {
    "entries": [
      {
        "request": {
          "method": "GET",
          "url": "https://httpbin.org/get?key=value",
          "queryString": [
            {
              "name": "foo",
              "value": "bar"
            },
            {
              "name": "foo",
              "value": "baz"
            },
            {
              "name": "baz",
              "value": "abc"
            }
          ]
        }
      }
    ]
  }
}
```

While running it through `fetch-har` so I could document the response we get back back into the HAR I noticed something was off about the query params:

```js
{
  args: { baz: 'abc', foo: 'baz', key: 'value?foo=bar' },
  headers: {
    Accept: '*//*',
    'Accept-Encoding': 'gzip,deflate',
    Host: 'httpbin.org',
    'User-Agent': 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
    'X-Amzn-Trace-Id': 'Root=1-61eb7346-4553137b5780d2416e2a96ab'
  },
  origin: '98.42.248.146',
  url: 'https://httpbin.org/get?key=value%3Ffoo=bar&foo=baz&baz=abc'
}
```

Turns out for as long as this library has been around we haven't been using `URLSearchParams` to compose query strings, and as a result haven't accounted for if a `request.url` already had one present. Granted this is an extreme edgecase as they should go into the `queryString` array but alas... a fun discovery!

## 🧬 Testing

Check out the test I added. The `query` fixture it's using is here: https://github.com/readmeio/har-examples/blob/main/src/query.har.js