### PR TITLE
feat: automatically polyfilling FormData with formdata-node if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,11 @@ npm install --save fetch-har
 ## Usage
 ```js
 require('isomorphic-fetch');
-const fetchHar = require('.');
 
-// If executing from an environment that dodoesn't normally provide fetch()
-// you'll need to polyfill some APIs in order to make `multipart/form-data`
-// requests.
-if (!globalThis.FormData) {
-  globalThis.Blob = require('formdata-node').Blob;
-  globalThis.File = require('formdata-node').File;
-  globalThis.FormData = require('formdata-node').FormData;
-}
+// If executing from an environment that dodoesn't normally provide `fetch()`
+// we'll automatically polyfill in the `Blob`, `File`, and `FormData` APIs
+// with the optional `formdata-node` package (provided you've installed it).
+const fetchHar = require('.');
 
 const har = {
   log: {
@@ -66,7 +61,7 @@ If you are executing `fetch-har` in a browser environment that supports the [For
 
 Unfortunately the most popular NPM package [form-data](https://npm.im/form-data) ships with a [non-spec compliant API](https://github.com/form-data/form-data/issues/124), and for this we don't recommend you use it, as if you use `fetch-har` to upload files it may not work.
 
-We recommend either [formdata-node](https://npm.im/formdata-node) or [formdata-polyfill](https://npm.im/formdata-polyfill).
+Though we recommend either [formdata-node](https://npm.im/formdata-node) or [formdata-polyfill](https://npm.im/formdata-polyfill) we prefer [formdata-node](https://npm.im/formdata-node) right now as it's CJS-compatible.
 
 #### Options
 ##### userAgent
@@ -89,7 +84,7 @@ await fetchHar(har, { files: {
 If you don't supply this option `fetch-har` will fallback to the data URL present within the supplied HAR. If no `files` option is present, and no data URL (via `param.value`) is present in the HAR, a fatal exception will be thrown.
 
 ##### multipartEncoder
-> ❗ If you are using `fetch-har` in Node you may need this option!
+> ❗ If you are using `fetch-har` in Node you may need this option to execute `multipart/form-data` requests!
 
 If you are running `fetch-har` within a Node environment and you're using `node-fetch@2`, or another `fetch` polyfill that does not support a spec-compliant `FormData` API, you will need to specify an encoder that will transform your `FormData` object into something that can be used with [Request.body](https://developer.mozilla.org/en-US/docs/Web/API/Request/body).
 

--- a/example.js
+++ b/example.js
@@ -1,14 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies, no-console */
 require('isomorphic-fetch');
-const fetchHar = require('.');
 
-// If executing from an environment that dodoesn't normally provide fetch() you'll need to polyfill some APIs in order
-// to make `multipart/form-data` requests.
-if (!globalThis.FormData) {
-  globalThis.Blob = require('formdata-node').Blob;
-  globalThis.File = require('formdata-node').File;
-  globalThis.FormData = require('formdata-node').FormData;
-}
+// If executing from an environment that dodoesn't normally provide `fetch()`
+// we'll automatically polyfill in the `Blob`, `File`, and `FormData` APIs
+// with the optional `formdata-node` package (provided you've installed it).
+const fetchHar = require('.');
 
 const har = {
   log: {

--- a/index.js
+++ b/index.js
@@ -23,6 +23,17 @@ if (!globalThis.File) {
   }
 }
 
+if (!globalThis.FormData) {
+  try {
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    globalThis.FormData = require('formdata-node').FormData;
+  } catch (e) {
+    throw new Error(
+      'Since you do not have the FormData API available in this environment you must install the optional `formdata-node` dependency.'
+    );
+  }
+}
+
 function isBrowser() {
   return typeof window !== 'undefined' && typeof document !== 'undefined';
 }


### PR DESCRIPTION
## 🧰 What's being changed?

This cleans up some of the usage around having to polyfill `FormData` in Node environments so that if you don't have it readily available we'll automatically do it ourselves if you've got the optional `formdata-node` package installed.

Doing this will help clean up the general usage of the library so that you can just load `isomorphic-fetch` (or `node-fetch` and then execute `fetchHar()` without having to do anything else special aside from the `multipartEncoder` option.

## 🧬 Testing

It's difficult to write a test for this because it assumes that a package isn't available, and I have no interest in attempting to mock out `require`, but this code works identical to how we're already auto-polyfilling in the `Blob` and `File` APIs.