### PR TITLE
fix: regression in query parameter handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -286,14 +286,17 @@ function constructRequest(har, opts = { userAgent: false, files: false, multipar
     }
   }
 
+  // We automaticaly assume that the HAR that we have already has query parameters encoded within it so we do **not**
+  // use the `URLSearchParams` API here for composing the query string.
   if ('queryString' in request && request.queryString.length) {
-    const queryParams = new URL(url).searchParams;
+    const urlObj = new URL(url);
 
+    const queryParams = Array.from(urlObj.searchParams).map(([k, v]) => `${k}=${v}`);
     request.queryString.forEach(q => {
-      queryParams.append(q.name, q.value);
+      queryParams.push(`${q.name}=${q.value}`);
     });
 
-    querystring = queryParams.toString();
+    querystring = queryParams.join('&');
   }
 
   if (opts.userAgent) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "form-data": "^4.0.0",
         "form-data-encoder": "^1.7.1",
         "formdata-node": "^4.3.2",
-        "har-examples": "^3.0.0",
+        "har-examples": "^3.1.0",
         "isomorphic-fetch": "^3.0.0",
         "mocha": "^9.1.4",
         "node-fetch": "^2.6.0",
@@ -9013,9 +9013,9 @@
       }
     },
     "node_modules/har-examples": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/har-examples/-/har-examples-3.0.0.tgz",
-      "integrity": "sha512-DnqeCc//Xe/OaTANuQ3e4CHwg1ZrnxsogNrPkj32P5Y3pe7Z0T6yVcL5bBS7i3grsI6HGUS3hfM8L7lQI/vn6g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/har-examples/-/har-examples-3.1.0.tgz",
+      "integrity": "sha512-0sUi31EY6Zhp8dySXaARgd+TTThkKi0SFBL/sotVEpS1FvuuCacEfqudF9t+UMUoMO/MKk/A4Tki+HRF5s6Qyg==",
       "dev": true,
       "engines": {
         "node": "^12 || ^14 || ^16"
@@ -23092,9 +23092,9 @@
       "dev": true
     },
     "har-examples": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/har-examples/-/har-examples-3.0.0.tgz",
-      "integrity": "sha512-DnqeCc//Xe/OaTANuQ3e4CHwg1ZrnxsogNrPkj32P5Y3pe7Z0T6yVcL5bBS7i3grsI6HGUS3hfM8L7lQI/vn6g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/har-examples/-/har-examples-3.1.0.tgz",
+      "integrity": "sha512-0sUi31EY6Zhp8dySXaARgd+TTThkKi0SFBL/sotVEpS1FvuuCacEfqudF9t+UMUoMO/MKk/A4Tki+HRF5s6Qyg==",
       "dev": true
     },
     "has": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "form-data": "^4.0.0",
     "form-data-encoder": "^1.7.1",
     "formdata-node": "^4.3.2",
-    "har-examples": "^3.0.0",
+    "har-examples": "^3.1.0",
     "isomorphic-fetch": "^3.0.0",
     "mocha": "^9.1.4",
     "node-fetch": "^2.6.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -93,6 +93,22 @@ describe('#fetch', function () {
       expect(res.url).to.equal('https://httpbin.org/get?key=value&foo=bar&foo=baz&baz=abc');
     });
 
+    it('should not double encode query parameters', async function () {
+      const res = await fetchHar(harExamples['query-encoded']).then(r => r.json());
+
+      expect(res.args).to.deep.equal({
+        array: ['something&nothing=true', 'nothing&something=false', 'another item'],
+        stringArray: 'where[4]=10',
+        stringHash: 'hash#data',
+        stringPound: 'something&nothing=true',
+        stringWeird: 'properties["$email"] == "testing"',
+      });
+
+      expect(res.url).to.equal(
+        'https://httpbin.org/anything?stringPound=something%26nothing%3Dtrue&stringHash=hash%23data&stringArray=where[4]%3D10&stringWeird=properties["%24email"] %3D%3D "testing"&array=something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=another item'
+      );
+    });
+
     it('should support requests with cookies', async function () {
       const res = await fetchHar(harExamples.cookies).then(r => r.json());
 


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes a regression I introduced in #239 regarding our handling of query strings.

When I initially noticed that we were failing to use the `URLSearchParams` API for composing query strings I failed to remember that we're already pre-encoding query strings into HARs in `@readme/oas-to-har` so by adding encoded query parameters into `URLSearchParams` they would end up being double encoded.

## 🧬 Testing

Check out the test I added for this, it uses this HAR I created in our [har-examples](https://npm.im/har-examples) package that has query strings pre-encoded: https://github.com/readmeio/har-examples/blob/main/src/query-encoded.har.js
