### PR TITLE
chore(deps-dev): removing eslint-plugin-mocha as a hard devdep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "chai": "^4.3.4",
         "eslint": "^8.7.0",
         "eslint-plugin-compat": "^4.0.1",
-        "eslint-plugin-mocha": "^10.0.3",
         "form-data": "^4.0.0",
         "form-data-encoder": "^1.7.1",
         "formdata-node": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "chai": "^4.3.4",
     "eslint": "^8.7.0",
     "eslint-plugin-compat": "^4.0.1",
-    "eslint-plugin-mocha": "^10.0.3",
     "form-data": "^4.0.0",
     "form-data-encoder": "^1.7.1",
     "formdata-node": "^4.3.2",


### PR DESCRIPTION
## 🧰 What's being changed?

Removing `eslint-plugin-mocha` as a hard devDep because the latest release of `@readme/eslint-config` includes it for us.
