### PR TITLE
feat: adding support for node 18, drop node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node:
-          - 12
           - 14
           - 16
+          - 18
 
     steps:
       - name: Checkout source

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "prettier": "^2.6.0"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16"
+        "node": ">=14"
       },
       "optionalDependencies": {
         "formdata-node": "^4.3.2"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Make a fetch request from a HAR definition",
   "main": "index.js",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": ">=14"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
## 🧰 Changes

* [x] Add support for Node 18, and getting tests running under it.
* [x] Drop support for Node 12.

## 🧬 QA & Testing

Node 18 tests should be passing! 😰 