### PR TITLE
fix: changing how we construct a `fetch` request to be compatible with `fetch-mock`

### DIFF
--- a/index.js
+++ b/index.js
@@ -320,7 +320,15 @@ function constructRequest(har, opts = { userAgent: false, files: false, multipar
 }
 
 function fetchHar(har, opts = { userAgent: false, files: false, multipartEncoder: false }) {
-  return fetch(constructRequest(har, opts));
+  // Though supplying `constructRequest` directly into `fetch` is perfectly fine, Nock doesn't
+  // currently work on Node 18, and in order to mock requests with this library on Node 18 you need
+  // to use `fetch-mock`, and `fetch-mock` isn't able to understand us supplying `Request` directly
+  // into `fetch`.
+  //
+  // https://github.com/nock/nock/issues/2336
+  // https://github.com/wheresrhys/fetch-mock/issues/156
+  const req = constructRequest(har, opts);
+  return fetch(req.url, req);
 }
 
 module.exports = fetchHar;


### PR DESCRIPTION
## 🧰 Changes

`fetch-mock` is expecting `fetch` calls to be composed of two+ arguments: a url and a `Request` object of options. The way that we construct it here is by supplying `fetch` a pre-constructed `Request` object so when you attempt to mock a request with this library with `fetch-mock` it throws this error:

> fetch-mock: Unrecognised Request object. Read the Config and Installation sections of the docs

## 🧬 QA & Testing

Though there's no functional changes here, everything should still be the same (god willing).