### PR TITLE
feat: rewriting the library in typescript, adding support for node 18

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 .nyc_output/
 coverage/
+dist/

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
-  "extends": ["@readme/eslint-config", "plugin:compat/recommended"],
+  "extends": [
+    "@readme/eslint-config",
+    "@readme/eslint-config/typescript"
+  ],
   "root": true,
   "env": {
     "es2020": true
@@ -14,5 +17,15 @@
       "Headers",
       "Request"
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["example.js"],
+      "rules": {
+        "@typescript-eslint/no-var-requires": "off",
+        "import/no-extraneous-dependencies": "off",
+        "no-console": "off"
+      }
+    }
+  ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - run: npm ci
+      - run: npm run build
       - run: npm run lint
 
   node_tests:
@@ -65,14 +66,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Install npm@7
-        run: npm install -g npm@7
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run tests
-        run: npx mocha
+      - run: npm ci
+      - run: npm run build
+      - run: npx mocha
 
   browser_tests:
     name: Browser
@@ -109,11 +105,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Install npm@7
-        run: npm install -g npm@7
-
-      - name: Install dependencies
-        run: npm ci
+      - run: npm ci
+      - run: npm run build
 
       # Chrome
       - uses: browser-actions/setup-chrome@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - run: npm ci
       - run: npm run build
-      - run: npm run test:only
+      - run: npm run test --ignore-scripts
 
   browser_tests:
     name: Browser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
+      # Node 14 still ships with npm@6 which doesn't install peerDeps by default.
+      - name: Install npm@7
+        if: matrix.node == '14'
+        run: npm install -g npm@7
+
       - run: npm ci
       - run: npm run build
       - run: npx mocha
@@ -104,6 +109,10 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+
+      # Node 14 still ships with npm@6 which doesn't install peerDeps by default.
+      - name: Install npm@7
+        run: npm install -g npm@7
 
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - run: npm ci
       - run: npm run build
-      - run: npx mocha
+      - run: npm run test:only
 
   browser_tests:
     name: Browser

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-coverage/
-node_modules/
 .nyc_output
+coverage/
+dist/
+node_modules/

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,13 @@
+{
+  "require": [
+    "test/helpers/init.js",
+    "ts-node/register"
+  ],
+  "watch-extensions": [
+    "ts"
+  ],
+  "watch-files": ["src/**/*.ts", "test/**/*.ts"],
+  "recursive": true,
+  "reporter": "spec",
+  "timeout": 200000
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
-coverage
+.nyc_output/
+coverage/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # fetch-har
-[![CI](https://github.com/readmeio/fetch-har/workflows/CI/badge.svg)](https://github.com/readmeio/fetch-har)
-
 Make a [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) request from a HAR definition.
 
+[![CI](https://github.com/readmeio/fetch-har/workflows/CI/badge.svg)](https://github.com/readmeio/fetch-har/)
+[![](https://img.shields.io/npm/v/fetch-har)](https://npm.im/fetch-har)
+[![License](https://img.shields.io/npm/l/fetch-har.svg)](LICENSE)
+
 [![](https://d3vv6lp55qjaqc.cloudfront.net/items/1M3C3j0I0s0j3T362344/Untitled-2.png)](https://readme.io)
+
+## Features
+
+- Supports Node 14+ (including the native `fetch` implementation in Node 18!).
+- Natively works in all browsers that support [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) without having to use any polyfils.
+- [Tested](https://github.com/readmeio/fetch-har/actions) across Chrome, Safari, Firefox on Mac, Windows, and Linux.
 
 ## Installation
 
@@ -18,7 +26,7 @@ require('isomorphic-fetch');
 // If executing from an environment that doesn't normally provide `fetch()`
 // we'll automatically polyfill in the `Blob`, `File`, and `FormData` APIs
 // with the optional `formdata-node` package (provided you've installed it).
-const fetchHar = require('.');
+const fetchHar = require('.').default;
 
 const har = {
   log: {

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ require('isomorphic-fetch');
 // If executing from an environment that doesn't normally provide `fetch()`
 // we'll automatically polyfill in the `Blob`, `File`, and `FormData` APIs
 // with the optional `formdata-node` package (provided you've installed it).
-const fetchHar = require('.').default;
+const fetchHAR = require('.').default;
 
 const har = {
   log: {
@@ -59,7 +59,7 @@ const har = {
   },
 };
 
-fetchHar(har)
+fetchHAR(har)
   .then(res => res.json())
   .then(console.log);
 ```
@@ -76,14 +76,14 @@ Though we recommend either [formdata-node](https://npm.im/formdata-node) or [for
 A custom `User-Agent` header to apply to your request. Please note that browsers have their own handling for these headers in `fetch()` calls so it may not work everywhere; it will always be sent in Node however.
 
 ```js
-await fetchHar(har, { userAgent: 'my-client/1.0' });
+await fetchHAR(har, { userAgent: 'my-client/1.0' });
 ```
 
 ##### files
 An optional object map you can supply to use for `multipart/form-data` file uploads in leu of relying on if the HAR you have has [data URLs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs). It supports Node file buffers and the [File](https://developer.mozilla.org/en-US/docs/Web/API/File) API.
 
 ```js
-await fetchHar(har, { files: {
+await fetchHAR(har, { files: {
   'owlbert.png': await fs.readFile('./owlbert.png'),
   'file.txt': document.querySelector('#some-file-input').files[0],
 } });
@@ -101,7 +101,22 @@ We recommend [form-data-encoder](https://npm.im/form-data-encoder).
 ```js
 const { FormDataEncoder } = require('form-data-encoder');
 
-await fetchHar(har, { multipartEncoder: FormDataEncoder });
+await fetchHAR(har, { multipartEncoder: FormDataEncoder });
 ```
 
 You do **not**, and shouldn't, need to use this option in browser environments.
+
+##### init
+This optional argument lets you supply any option that's available to supply to the [Request constructor](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request).
+
+```js
+await fetchHAR(har, {
+  init: {
+    headers: new Headers({
+      'x-custom-header': 'buster',
+    }),
+  },
+})
+```
+
+> ❗ Note that if you supply `body` or `credentials` to this option they may be overridden by what your HAR requires.

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ npm install --save fetch-har
 ```js
 require('isomorphic-fetch');
 
-// If executing from an environment that doesn't normally provide `fetch()`
-// we'll automatically polyfill in the `Blob`, `File`, and `FormData` APIs
-// with the optional `formdata-node` package (provided you've installed it).
-const fetchHAR = require('.').default;
+// If executing from an environment that doesn't normally provide `fetch()` we'll automatically
+// polyfill in the `Blob`, `File`, and `FormData` APIs with the optional `formdata-node` package
+// (provided you've installed it).
+const fetchHAR = require('fetch-har').default;
+// import fetchHAR from 'fetch-har'); // Or if you're in an ESM codebase.
 
 const har = {
   log: {

--- a/example.js
+++ b/example.js
@@ -3,7 +3,7 @@ require('isomorphic-fetch');
 // If executing from an environment that doesn't normally provide `fetch()`
 // we'll automatically polyfill in the `Blob`, `File`, and `FormData` APIs
 // with the optional `formdata-node` package (provided you've installed it).
-const fetchHar = require('.').default;
+const fetchHAR = require('.').default;
 
 const har = {
   log: {
@@ -36,6 +36,6 @@ const har = {
   },
 };
 
-fetchHar(har)
+fetchHAR(har)
   .then(res => res.json())
   .then(console.log);

--- a/example.js
+++ b/example.js
@@ -1,10 +1,9 @@
-/* eslint-disable import/no-extraneous-dependencies, no-console */
 require('isomorphic-fetch');
 
 // If executing from an environment that doesn't normally provide `fetch()`
 // we'll automatically polyfill in the `Blob`, `File`, and `FormData` APIs
 // with the optional `formdata-node` package (provided you've installed it).
-const fetchHar = require('.');
+const fetchHar = require('.').default;
 
 const har = {
   log: {

--- a/index.js
+++ b/index.js
@@ -320,7 +320,15 @@ function constructRequest(har, opts = { userAgent: false, files: false, multipar
 }
 
 function fetchHar(har, opts = { userAgent: false, files: false, multipartEncoder: false }) {
-  return fetch(constructRequest(har, opts));
+  // Though supplying `constructRequest` directly into `fetch` is perfectly fine, Nock doesn't
+  // currently work on Node 18, and in order to mock requests with this library on Node 18 you need
+  // to use `fetch-mock`, and `fetch-mock` isn't able to understand us supplying `Request` directly
+  // into `fetch`.
+  //
+  // https://github.com/nock/nock/issues/2336
+  // https://github.com/wheresrhys/fetch-mock/issues/156
+  const req = constructRequest(har, opts);
+  return fetch(req.url, req);
 }
 
 module.exports = fetchHar;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 const { karmaConfig } = require('@jsdevtools/karma-config');
 const { host } = require('@jsdevtools/host-environment');
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,17 +12,22 @@ module.exports = karmaConfig({
     edge: false,
     ie: false,
   },
+  tests: ['test/*.ts'],
   config: {
-    exclude: [
-      // Exclude these tests because some of the APIs are HUGE and cause timeouts.
-      // We still test them in Node though.
-      // "test/specs/real-world/*",
-      'test/node-quirks.test.js',
-    ],
     client: {
       mocha: {
         // Windows CI sometimes takes longer than 2s to run some tests.
         timeout: 15000,
+      },
+    },
+    exclude: ['test/node-quirks.test.ts'],
+    webpack: {
+      resolve: {
+        extensions: ['.js', '.ts'],
+      },
+      mode: 'production',
+      module: {
+        rules: [{ test: /\.ts$/, use: 'ts-loader' }],
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "node-fetch": "^2.6.0",
         "nyc": "^15.1.0",
         "prettier": "^2.6.2",
+        "ts-loader": "^7.0.5",
         "ts-node": "^10.7.0",
         "typescript": "^4.6.3",
         "undici": "^5.0.0"
@@ -2199,33 +2200,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@jsdevtools/karma-config/node_modules/enhanced-resolve": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
-      "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.5.0",
-        "tapable": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@jsdevtools/karma-config/node_modules/enhanced-resolve/node_modules/memory-fs": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-      "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-      "dev": true,
-      "dependencies": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4.3.0 <5.0.0 || >=5.10"
-      }
-    },
     "node_modules/@jsdevtools/karma-config/node_modules/eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -2465,21 +2439,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@jsdevtools/karma-config/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
     "node_modules/@jsdevtools/karma-config/node_modules/schema-utils": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
@@ -2523,24 +2482,6 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@jsdevtools/karma-config/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/@jsdevtools/karma-config/node_modules/tapable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@jsdevtools/karma-config/node_modules/terser": {
@@ -6818,6 +6759,57 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+      "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.5.0",
+        "tapable": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/enhanced-resolve/node_modules/memory-fs": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+      "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+      "dev": true,
+      "dependencies": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.3.0 <5.0.0 || >=5.10"
+      }
+    },
+    "node_modules/enhanced-resolve/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/enhanced-resolve/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/ent": {
       "version": "2.2.0",
@@ -14792,6 +14784,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tapable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
@@ -15089,6 +15090,60 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ts-loader": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-7.0.5.tgz",
+      "integrity": "sha512-zXypEIT6k3oTc+OZNx/cqElrsbBtYqDknf48OZos0NQ3RTt045fBIU8RRSu+suObBzYB355aIPGOe/3kj9h7Ig==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.3.0",
+        "enhanced-resolve": "^4.0.0",
+        "loader-utils": "^1.0.2",
+        "micromatch": "^4.0.0",
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/ts-loader/node_modules/json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/ts-loader/node_modules/loader-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/ts-loader/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/ts-node": {
@@ -17913,29 +17968,6 @@
             }
           }
         },
-        "enhanced-resolve": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
-          "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "memory-fs": "^0.5.0",
-            "tapable": "^1.0.0"
-          },
-          "dependencies": {
-            "memory-fs": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-              "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-              "dev": true,
-              "requires": {
-                "errno": "^0.1.3",
-                "readable-stream": "^2.0.1"
-              }
-            }
-          }
-        },
         "eslint-scope": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -18121,21 +18153,6 @@
             "find-up": "^3.0.0"
           }
         },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
         "schema-utils": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
@@ -18166,21 +18183,6 @@
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "tapable": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-          "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
           "dev": true
         },
         "terser": {
@@ -21704,6 +21706,53 @@
       "peer": true,
       "requires": {
         "@socket.io/base64-arraybuffer": "~1.0.2"
+      }
+    },
+    "enhanced-resolve": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+      "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.5.0",
+        "tapable": "^1.0.0"
+      },
+      "dependencies": {
+        "memory-fs": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+          "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "ent": {
@@ -27940,6 +27989,12 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "tapable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+      "dev": true
+    },
     "tar-fs": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
@@ -28207,6 +28262,47 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
+      }
+    },
+    "ts-loader": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-7.0.5.tgz",
+      "integrity": "sha512-zXypEIT6k3oTc+OZNx/cqElrsbBtYqDknf48OZos0NQ3RTt045fBIU8RRSu+suObBzYB355aIPGOe/3kj9h7Ig==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "enhanced-resolve": "^4.0.0",
+        "loader-utils": "^1.0.2",
+        "micromatch": "^4.0.0",
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "ts-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,19 +15,27 @@
       "devDependencies": {
         "@jsdevtools/host-environment": "^2.1.2",
         "@jsdevtools/karma-config": "^3.1.7",
-        "@readme/eslint-config": "^8.7.1",
+        "@readme/eslint-config": "^8.7.3",
+        "@types/chai": "^4.3.1",
+        "@types/har-format": "^1.2.8",
+        "@types/mocha": "^9.1.1",
+        "@types/node": "^17.0.29",
+        "@types/parse-data-url": "^3.0.0",
+        "@types/readable-stream": "^2.3.13",
         "chai": "^4.3.4",
         "eslint": "^8.14.0",
-        "eslint-plugin-compat": "^4.0.1",
         "form-data": "^4.0.0",
         "form-data-encoder": "^1.7.1",
         "formdata-node": "^4.3.2",
-        "har-examples": "^3.1.0",
+        "har-examples": "^3.1.1",
         "isomorphic-fetch": "^3.0.0",
         "mocha": "^9.2.2",
         "node-fetch": "^2.6.0",
         "nyc": "^15.1.0",
-        "prettier": "^2.6.2"
+        "prettier": "^2.6.2",
+        "ts-node": "^10.7.0",
+        "typescript": "^4.6.3",
+        "undici": "^5.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -1738,6 +1746,27 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.29.0.tgz",
@@ -2757,12 +2786,6 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true
     },
-    "node_modules/@mdn/browser-compat-data": {
-      "version": "3.3.14",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz",
-      "integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==",
-      "dev": true
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2805,9 +2828,9 @@
       "dev": true
     },
     "node_modules/@readme/eslint-config": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.7.1.tgz",
-      "integrity": "sha512-dEVnRy+ij4JEQstdJNaTJzZ6x6AfqNgxJKj/yIzwtWxRFsaxUIlLPVbuSuPcfuvOEqlJuMDwpl1COb//0j53Jw==",
+      "version": "8.7.3",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.7.3.tgz",
+      "integrity": "sha512-45Ri7wXKKw9xZjyW01MqrMuBA2KjbYzpd80v0V93LcmSwlMao45thvOO2SkizTG6WwVuVeT56A5N3exr444o1w==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.20.0",
@@ -2824,7 +2847,7 @@
         "eslint-plugin-jest-formatting": "^3.0.0",
         "eslint-plugin-jsdoc": "^39.2.5",
         "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-mocha": "^10.0.4",
+        "eslint-plugin-mocha": "10.0.3",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.17.0",
@@ -2919,6 +2942,30 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
     "node_modules/@types/aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
@@ -2936,6 +2983,12 @@
         "@types/node": "*",
         "@types/responselike": "*"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
+      "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
+      "dev": true
     },
     "node_modules/@types/color-name": {
       "version": "1.1.1",
@@ -2964,6 +3017,12 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/@types/har-format": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+      "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ==",
+      "dev": true
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -2991,10 +3050,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/mocha": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "dev": true
+    },
     "node_modules/@types/node": {
-      "version": "16.11.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.21.tgz",
-      "integrity": "sha512-Pf8M1XD9i1ksZEcCP8vuSNwooJ/bZapNmIzpmsMaL+jMI+8mEYU3PKvs+xDNuQcJWF/x24WzY4qxLtB0zNow9A==",
+      "version": "17.0.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+      "integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -3002,6 +3067,15 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "node_modules/@types/parse-data-url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-data-url/-/parse-data-url-3.0.0.tgz",
+      "integrity": "sha512-W7j36KpA780hfh4jyQoLab3+uS+Svmug7GgdJoHe/4ak66ws6ar5/wD8Cqch01O+UT69pzfsBtpNzrF4/6ThBw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/puppeteer": {
       "version": "5.4.4",
@@ -3019,6 +3093,16 @@
       "dev": true,
       "dependencies": {
         "@types/puppeteer": "*"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.13.tgz",
+      "integrity": "sha512-4JSCx8EUzaW9Idevt+9lsRAt1lcSccoQfE+AouM1gk8sFxnnytKNIO3wTl9Dy+4m6jRJ1yXhboLHHT/LXBQiEw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "*"
       }
     },
     "node_modules/@types/responselike": {
@@ -3565,6 +3649,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
@@ -3841,6 +3934,12 @@
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -4020,15 +4119,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ast-metadata-inferer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz",
-      "integrity": "sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==",
-      "dev": true,
-      "dependencies": {
-        "@mdn/browser-compat-data": "^3.3.14"
       }
     },
     "node_modules/ast-types-flow": {
@@ -5740,6 +5830,12 @@
         "sha.js": "^2.4.8"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -7057,104 +7153,6 @@
         "eslint": ">=3.0.0"
       }
     },
-    "node_modules/eslint-plugin-compat": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.0.2.tgz",
-      "integrity": "sha512-xqvoO54CLTVaEYGMzhu35Wzwk/As7rCvz/2dqwnFiWi0OJccEtGIn+5qq3zqIu9nboXlpdBN579fZcItC73Ycg==",
-      "dev": true,
-      "dependencies": {
-        "@mdn/browser-compat-data": "^4.1.5",
-        "ast-metadata-inferer": "^0.7.0",
-        "browserslist": "^4.16.8",
-        "caniuse-lite": "^1.0.30001304",
-        "core-js": "^3.16.2",
-        "find-up": "^5.0.0",
-        "lodash.memoize": "4.1.2",
-        "semver": "7.3.5"
-      },
-      "engines": {
-        "node": ">=9.x"
-      },
-      "peerDependencies": {
-        "eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-compat/node_modules/@mdn/browser-compat-data": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.5.tgz",
-      "integrity": "sha512-rb2LEhclR/Ykf/biC2HrZmVonqnfTL8RhsL9wdMCGmw1xfeLFqGGZLKWypob2/i15SqgmEHbtcgJZ9kwWPbKtQ==",
-      "dev": true
-    },
-    "node_modules/eslint-plugin-compat/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-compat/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-compat/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-compat/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-compat/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/eslint-plugin-es": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
@@ -7403,13 +7401,13 @@
       "dev": true
     },
     "node_modules/eslint-plugin-mocha": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.4.tgz",
-      "integrity": "sha512-8wzAeepVY027oBHz/TmBmUr7vhVqoC1KTFeDybFLhbaWKx+aQ7fJJVuUsqcUy+L+G+XvgQBJY+cbAf7hl5DF7Q==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.3.tgz",
+      "integrity": "sha512-9mM7PZGxfejpjey+MrG0Cu3Lc8MyA5E2s7eUCdHXgS4SY/H9zLuwa7wVAjnEaoDjbBilA+0bPEB+iMO7lBUPcg==",
       "dev": true,
       "dependencies": {
         "eslint-utils": "^3.0.0",
-        "ramda": "^0.28.0"
+        "ramda": "^0.27.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -9185,13 +9183,10 @@
       }
     },
     "node_modules/har-examples": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/har-examples/-/har-examples-3.1.0.tgz",
-      "integrity": "sha512-0sUi31EY6Zhp8dySXaARgd+TTThkKi0SFBL/sotVEpS1FvuuCacEfqudF9t+UMUoMO/MKk/A4Tki+HRF5s6Qyg==",
-      "dev": true,
-      "engines": {
-        "node": "^12 || ^14 || ^16"
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/har-examples/-/har-examples-3.1.1.tgz",
+      "integrity": "sha512-QE+C31xSyMAGNGOAS6e4naZfFBqU6FeCzMPN2kOwat8FsVZ/ltuokZcuWuRGN2kceWU7KzfwhiplYhb0VbMrWQ==",
+      "dev": true
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -10801,12 +10796,6 @@
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -11007,6 +10996,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/map-cache": {
       "version": "0.2.2",
@@ -13066,14 +13061,10 @@
       }
     },
     "node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
+      "dev": true
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -15100,6 +15091,58 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.0",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -15227,7 +15270,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
       "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15278,6 +15320,15 @@
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.0.0.tgz",
+      "integrity": "sha512-VhUpiZ3No1DOPPQVQnsDZyfcbTTcHdcgWej1PdFnSvOeJmOVDgiOHkunJmBLfmjt4CqgPQddPVjSWW0dsTs5Yg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.18"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -15570,6 +15621,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "node_modules/valid-data-url": {
@@ -16242,6 +16299,15 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -17463,6 +17529,21 @@
       "dev": true,
       "peer": true
     },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
     "@es-joy/jsdoccomment": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.29.0.tgz",
@@ -18293,12 +18374,6 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true
     },
-    "@mdn/browser-compat-data": {
-      "version": "3.3.14",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz",
-      "integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==",
-      "dev": true
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -18332,9 +18407,9 @@
       "dev": true
     },
     "@readme/eslint-config": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.7.1.tgz",
-      "integrity": "sha512-dEVnRy+ij4JEQstdJNaTJzZ6x6AfqNgxJKj/yIzwtWxRFsaxUIlLPVbuSuPcfuvOEqlJuMDwpl1COb//0j53Jw==",
+      "version": "8.7.3",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.7.3.tgz",
+      "integrity": "sha512-45Ri7wXKKw9xZjyW01MqrMuBA2KjbYzpd80v0V93LcmSwlMao45thvOO2SkizTG6WwVuVeT56A5N3exr444o1w==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.20.0",
@@ -18351,7 +18426,7 @@
         "eslint-plugin-jest-formatting": "^3.0.0",
         "eslint-plugin-jsdoc": "^39.2.5",
         "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-mocha": "^10.0.4",
+        "eslint-plugin-mocha": "10.0.3",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.17.0",
@@ -18417,6 +18492,30 @@
         }
       }
     },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
     "@types/aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
@@ -18434,6 +18533,12 @@
         "@types/node": "*",
         "@types/responselike": "*"
       }
+    },
+    "@types/chai": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
+      "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
+      "dev": true
     },
     "@types/color-name": {
       "version": "1.1.1",
@@ -18462,6 +18567,12 @@
       "dev": true,
       "peer": true
     },
+    "@types/har-format": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+      "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ==",
+      "dev": true
+    },
     "@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -18489,10 +18600,16 @@
         "@types/node": "*"
       }
     },
+    "@types/mocha": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "dev": true
+    },
     "@types/node": {
-      "version": "16.11.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.21.tgz",
-      "integrity": "sha512-Pf8M1XD9i1ksZEcCP8vuSNwooJ/bZapNmIzpmsMaL+jMI+8mEYU3PKvs+xDNuQcJWF/x24WzY4qxLtB0zNow9A==",
+      "version": "17.0.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+      "integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -18500,6 +18617,15 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "@types/parse-data-url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-data-url/-/parse-data-url-3.0.0.tgz",
+      "integrity": "sha512-W7j36KpA780hfh4jyQoLab3+uS+Svmug7GgdJoHe/4ak66ws6ar5/wD8Cqch01O+UT69pzfsBtpNzrF4/6ThBw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/puppeteer": {
       "version": "5.4.4",
@@ -18517,6 +18643,16 @@
       "dev": true,
       "requires": {
         "@types/puppeteer": "*"
+      }
+    },
+    "@types/readable-stream": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.13.tgz",
+      "integrity": "sha512-4JSCx8EUzaW9Idevt+9lsRAt1lcSccoQfE+AouM1gk8sFxnnytKNIO3wTl9Dy+4m6jRJ1yXhboLHHT/LXBQiEw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "safe-buffer": "*"
       }
     },
     "@types/responselike": {
@@ -18926,6 +19062,12 @@
       "dev": true,
       "requires": {}
     },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
+    },
     "agent-base": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
@@ -19146,6 +19288,12 @@
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -19288,15 +19436,6 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
-    },
-    "ast-metadata-inferer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz",
-      "integrity": "sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==",
-      "dev": true,
-      "requires": {
-        "@mdn/browser-compat-data": "^3.3.14"
-      }
     },
     "ast-types-flow": {
       "version": "0.0.7",
@@ -20732,6 +20871,12 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -21983,73 +22128,6 @@
       "dev": true,
       "requires": {}
     },
-    "eslint-plugin-compat": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.0.2.tgz",
-      "integrity": "sha512-xqvoO54CLTVaEYGMzhu35Wzwk/As7rCvz/2dqwnFiWi0OJccEtGIn+5qq3zqIu9nboXlpdBN579fZcItC73Ycg==",
-      "dev": true,
-      "requires": {
-        "@mdn/browser-compat-data": "^4.1.5",
-        "ast-metadata-inferer": "^0.7.0",
-        "browserslist": "^4.16.8",
-        "caniuse-lite": "^1.0.30001304",
-        "core-js": "^3.16.2",
-        "find-up": "^5.0.0",
-        "lodash.memoize": "4.1.2",
-        "semver": "7.3.5"
-      },
-      "dependencies": {
-        "@mdn/browser-compat-data": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.5.tgz",
-          "integrity": "sha512-rb2LEhclR/Ykf/biC2HrZmVonqnfTL8RhsL9wdMCGmw1xfeLFqGGZLKWypob2/i15SqgmEHbtcgJZ9kwWPbKtQ==",
-          "dev": true
-        },
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "dev": true,
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        }
-      }
-    },
     "eslint-plugin-es": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
@@ -22211,13 +22289,13 @@
       }
     },
     "eslint-plugin-mocha": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.4.tgz",
-      "integrity": "sha512-8wzAeepVY027oBHz/TmBmUr7vhVqoC1KTFeDybFLhbaWKx+aQ7fJJVuUsqcUy+L+G+XvgQBJY+cbAf7hl5DF7Q==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.3.tgz",
+      "integrity": "sha512-9mM7PZGxfejpjey+MrG0Cu3Lc8MyA5E2s7eUCdHXgS4SY/H9zLuwa7wVAjnEaoDjbBilA+0bPEB+iMO7lBUPcg==",
       "dev": true,
       "requires": {
         "eslint-utils": "^3.0.0",
-        "ramda": "^0.28.0"
+        "ramda": "^0.27.1"
       }
     },
     "eslint-plugin-node": {
@@ -23407,9 +23485,9 @@
       "dev": true
     },
     "har-examples": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/har-examples/-/har-examples-3.1.0.tgz",
-      "integrity": "sha512-0sUi31EY6Zhp8dySXaARgd+TTThkKi0SFBL/sotVEpS1FvuuCacEfqudF9t+UMUoMO/MKk/A4Tki+HRF5s6Qyg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/har-examples/-/har-examples-3.1.1.tgz",
+      "integrity": "sha512-QE+C31xSyMAGNGOAS6e4naZfFBqU6FeCzMPN2kOwat8FsVZ/ltuokZcuWuRGN2kceWU7KzfwhiplYhb0VbMrWQ==",
       "dev": true
     },
     "has": {
@@ -24649,12 +24727,6 @@
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
-    "lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
-    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -24812,6 +24884,12 @@
           "dev": true
         }
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "map-cache": {
       "version": "0.2.2",
@@ -26442,9 +26520,9 @@
       "dev": true
     },
     "ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
       "dev": true
     },
     "randombytes": {
@@ -28131,6 +28209,35 @@
         "escape-string-regexp": "^1.0.2"
       }
     },
+    "ts-node": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.0",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -28232,8 +28339,7 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
       "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.31",
@@ -28262,6 +28368,12 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "undici": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.0.0.tgz",
+      "integrity": "sha512-VhUpiZ3No1DOPPQVQnsDZyfcbTTcHdcgWej1PdFnSvOeJmOVDgiOHkunJmBLfmjt4CqgPQddPVjSWW0dsTs5Yg==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -28508,6 +28620,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "valid-data-url": {
@@ -29060,6 +29178,12 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -2,20 +2,23 @@
   "name": "fetch-har",
   "version": "7.0.0",
   "description": "Make a fetch request from a HAR definition",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "engines": {
     "node": ">=14"
   },
   "scripts": {
-    "lint": "eslint .",
+    "build": "tsc",
+    "lint": "eslint . --ext .js,.ts",
+    "prebuild": "rm -rf dist/ @types/",
+    "prepack": "npm run build",
     "pretest": "npm run lint",
-    "prettier": "prettier --list-different --write \"./**.js\"",
+    "prettier": "prettier --list-different --write \"./**/**.{js,ts}\"",
     "release": "npx conventional-changelog-cli -i CHANGELOG.md -s",
-    "serve": "node __tests__/server.js",
     "test:browser": "karma start --single-run",
     "test:browser:chrome": "karma start --browsers=Chrome --single-run=false",
     "test:browser:debug": "karma start --single-run=false",
-    "test": "nyc mocha"
+    "test": "nyc mocha \"test/**/*.test.ts\""
   },
   "repository": {
     "type": "git",
@@ -36,19 +39,27 @@
   "devDependencies": {
     "@jsdevtools/host-environment": "^2.1.2",
     "@jsdevtools/karma-config": "^3.1.7",
-    "@readme/eslint-config": "^8.7.1",
+    "@readme/eslint-config": "^8.7.3",
+    "@types/chai": "^4.3.1",
+    "@types/har-format": "^1.2.8",
+    "@types/mocha": "^9.1.1",
+    "@types/node": "^17.0.29",
+    "@types/parse-data-url": "^3.0.0",
+    "@types/readable-stream": "^2.3.13",
     "chai": "^4.3.4",
     "eslint": "^8.14.0",
-    "eslint-plugin-compat": "^4.0.1",
     "form-data": "^4.0.0",
     "form-data-encoder": "^1.7.1",
     "formdata-node": "^4.3.2",
-    "har-examples": "^3.1.0",
+    "har-examples": "^3.1.1",
     "isomorphic-fetch": "^3.0.0",
     "mocha": "^9.2.2",
     "node-fetch": "^2.6.0",
     "nyc": "^15.1.0",
-    "prettier": "^2.6.2"
+    "prettier": "^2.6.2",
+    "ts-node": "^10.7.0",
+    "typescript": "^4.6.3",
+    "undici": "^5.0.0"
   },
   "browserslist": [
     "last 2 versions"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:browser": "karma start --single-run",
     "test:browser:chrome": "karma start --browsers=Chrome --single-run=false",
     "test:browser:debug": "karma start --single-run=false",
-    "test": "nyc mocha \"test/**/*.test.ts\""
+    "test": "nyc mocha \"test/**/*.test.ts\"",
+    "test:only": "nyc mocha \"test/**/*.test.ts\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "node-fetch": "^2.6.0",
     "nyc": "^15.1.0",
     "prettier": "^2.6.2",
+    "ts-loader": "^7.0.5",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.3",
     "undici": "^5.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ export default function fetchHAR(har: Har, opts: FetchHAROptions = {}) {
           // when building code snippets!
           //
           // https://github.com/github/fetch/issues/263#issuecomment-209530977
-          (req.headers as Headers).set('Content-Type', request.postData.mimeType);
+          headers.set('Content-Type', request.postData.mimeType);
 
           const encodedParams = new URLSearchParams();
           request.postData.params.forEach(param => encodedParams.set(param.name, param.value));

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ function isFormData(value: any) {
   );
 }
 
-export default function fetchHar(har: Har, opts: FetchHAROptions = {}) {
+export default function fetchHAR(har: Har, opts: FetchHAROptions = {}) {
   if (!har) throw new Error('Missing HAR definition');
   if (!har.log || !har.log.entries || !har.log.entries.length) throw new Error('Missing log.entries array');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,5 +344,5 @@ export default function fetchHAR(har: Har, opts: FetchHAROptions = {}) {
 
   options.headers = headers;
 
-  return fetch(`${url.split('?')[0]}${querystring ? `?${querystring}` : ''}`, req);
+  return fetch(`${url.split('?')[0]}${querystring ? `?${querystring}` : ''}`, options);
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,7 +1,3 @@
 {
-  "extends": ["@readme/eslint-config/testing-mocha"],
-  "plugins": ["mocha"],
-  "rules": {
-    "compat/compat": "off"
-  }
+  "extends": ["@readme/eslint-config/testing-mocha"]
 }

--- a/test/browser-quirks.test.ts
+++ b/test/browser-quirks.test.ts
@@ -1,17 +1,18 @@
-require('isomorphic-fetch');
+import 'isomorphic-fetch';
 
-const { host } = require('@jsdevtools/host-environment');
-const { expect } = require('chai');
-const fetchHar = require('..');
-const harExamples = require('har-examples');
+import { host } from '@jsdevtools/host-environment';
+import { expect } from 'chai';
+import fetchHar from '../src';
+import harExamples from 'har-examples';
 
-const owlbert = require('./fixtures/owlbert.dataurl.json');
-const owlbertShrubDataURL = require('./fixtures/owlbert-shrub.dataurl.json');
+import owlbert from './fixtures/owlbert.dataurl.json';
+import owlbertShrubDataURL from './fixtures/owlbert-shrub.dataurl.json';
 
 describe('#fetch (Browser-only quirks)', function () {
   beforeEach(function () {
     if (host.node) {
-      this.skip('This test suite should only run in the browser.');
+      // This test suite should only run in the browser.
+      this.skip();
     }
   });
 

--- a/test/browser-quirks.test.ts
+++ b/test/browser-quirks.test.ts
@@ -2,18 +2,22 @@ import 'isomorphic-fetch';
 
 import { host } from '@jsdevtools/host-environment';
 import { expect } from 'chai';
-import fetchHar from '../src';
 import harExamples from 'har-examples';
 
 import owlbert from './fixtures/owlbert.dataurl.json';
 import owlbertShrubDataURL from './fixtures/owlbert-shrub.dataurl.json';
 
 describe('#fetch (Browser-only quirks)', function () {
+  let fetchHAR;
+
   beforeEach(function () {
     if (host.node) {
       // This test suite should only run in the browser.
       this.skip();
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    fetchHAR = require('../src').default;
   });
 
   describe('binary handling', function () {
@@ -21,7 +25,7 @@ describe('#fetch (Browser-only quirks)', function () {
       it('should support a File `files` mapping override for a raw payload data URL', async function () {
         // In the HAR is `owlbert.png` but we want to adhoc override that with the contents of `owlbert-shrub.png` here
         // to ensure that the override works.
-        const res = await fetchHar(harExamples['image-png'], {
+        const res = await fetchHAR(harExamples['image-png'], {
           files: {
             'owlbert.png': new File([owlbertShrubDataURL], 'owlbert.png', { type: 'image/png' }),
           },
@@ -41,7 +45,7 @@ describe('#fetch (Browser-only quirks)', function () {
 
   describe('multipart/form-data', function () {
     it("should support a `multipart/form-data` request that's a standard object", async function () {
-      const res = await fetchHar(harExamples['multipart-form-data']).then(r => r.json());
+      const res = await fetchHAR(harExamples['multipart-form-data']).then(r => r.json());
 
       expect(res.form).to.deep.equal({ foo: 'bar' });
       expect(parseInt(res.headers['Content-Length'], 10)).to.be.at.least(133);
@@ -49,7 +53,7 @@ describe('#fetch (Browser-only quirks)', function () {
     });
 
     it('should support a `multipart/form-data` request with a plaintext file encoded in the HAR', async function () {
-      const res = await fetchHar(harExamples['multipart-data']).then(r => r.json());
+      const res = await fetchHAR(harExamples['multipart-data']).then(r => r.json());
       expect(res.files).to.deep.equal({ foo: 'Hello World' });
 
       expect(parseInt(res.headers['Content-Length'], 10)).to.be.at.least(189);
@@ -58,13 +62,13 @@ describe('#fetch (Browser-only quirks)', function () {
 
     it('should throw an error if `fileName` is present without `value` or a mapping', function () {
       expect(() => {
-        fetchHar(harExamples['multipart-file']);
+        fetchHAR(harExamples['multipart-file']);
       }).to.throw(/doesn't have access to the filesystem/);
     });
 
     describe('`files` option', function () {
       it('should support File objects', async function () {
-        const res = await fetchHar(harExamples['multipart-data-dataurl'], {
+        const res = await fetchHAR(harExamples['multipart-data-dataurl'], {
           files: {
             'owlbert.png': new File([owlbert], 'owlbert.png', { type: 'image/png' }),
           },
@@ -77,7 +81,7 @@ describe('#fetch (Browser-only quirks)', function () {
 
       it('should throw on an unsupported type', function () {
         expect(() => {
-          fetchHar(harExamples['multipart-data-dataurl'], {
+          fetchHAR(harExamples['multipart-data-dataurl'], {
             files: {
               'owlbert.png': new Blob([owlbert], { type: 'image/png' }),
             },
@@ -88,7 +92,7 @@ describe('#fetch (Browser-only quirks)', function () {
 
     describe('data URLs', function () {
       it('should be able to handle a `multipart/form-data` payload with a base64-encoded data URL file', async function () {
-        const res = await fetchHar(harExamples['multipart-data-dataurl']).then(r => r.json());
+        const res = await fetchHAR(harExamples['multipart-data-dataurl']).then(r => r.json());
 
         expect(res.files).to.deep.equal({ foo: owlbert });
         expect(parseInt(res.headers['Content-Length'], 10)).to.be.at.least(758);
@@ -104,7 +108,7 @@ describe('#fetch (Browser-only quirks)', function () {
             `name=${encodeURIComponent('owlbert (1).png')};`
           );
 
-        const res = await fetchHar(har).then(r => r.json());
+        const res = await fetchHAR(har).then(r => r.json());
         expect(res.files).to.deep.equal({ foo: owlbert.replace('owlbert.png', encodeURIComponent('owlbert (1).png')) });
         expect(parseInt(res.headers['Content-Length'], 10)).to.be.at.least(768);
         expect(res.headers['Content-Type']).to.match(/^multipart\/form-data; boundary=(.*)$/);

--- a/test/helpers/init.js
+++ b/test/helpers/init.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const path = require('path');
+
+process.env.TS_NODE_PROJECT = path.resolve('test/tsconfig.json');
+process.env.NODE_ENV = 'development';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,42 +1,10 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable import/first */
 import type { VersionInfo } from '@jsdevtools/host-environment';
 import type { Har } from 'har-format';
 import 'isomorphic-fetch';
 import { host } from '@jsdevtools/host-environment';
 
-/**
- * Under Node 18's native `fetch` implementation if a `File` global doesn't exist it'll polyfill
- * its own implementation. Normally this works fine, but its implementation is **different**
- * than the one that `formdata-node` ships and when we use the `formdata-node` one under Node 18
- * `type` options that we set into `File` instances don't get picked up, resulting in multipart
- * payloads being sent as `application/octet-stream` instead of whatever content type was attached
- * to that file.
- *
- * This behavior also extends to Undici's usage of `Blob` as well where the `Blob` that ships with
- * `formdata-node` behaves differently than the `Blob` that is part of the Node `buffer` module,
- * which Undici wants you to use.
- *
- * This code will only be loaded if we're running this test within a Node environment as `NODE_ENV`
- * is set to `production` when we run tests through Karma.
- */
-if (process.env.NODE_ENV !== 'production') {
-  if (!globalThis.File) {
-    globalThis.FormData = require('formdata-node').FormData;
-  }
-
-  const isNode18 = (host.node as VersionInfo).version >= 18;
-  if (isNode18) {
-    globalThis.File = require('undici').File;
-    globalThis.Blob = require('buffer').Blob;
-  } else {
-    globalThis.File = require('formdata-node').File;
-    globalThis.Blob = require('formdata-node').Blob;
-  }
-}
-
 import { expect } from 'chai';
-import fetchHar from '../src';
 import harExamples from 'har-examples';
 
 import owlbertDataURL from './fixtures/owlbert.dataurl.json';
@@ -45,10 +13,46 @@ import invalidHeadersHAR from './fixtures/invalid-headers.har.json';
 import urlEncodedWithAuthHAR from './fixtures/urlencoded-with-auth.har.json';
 
 describe('#fetch', function () {
+  let fetchHAR;
+
+  beforeEach(function () {
+    /**
+     * Under Node 18's native `fetch` implementation if a `File` global doesn't exist it'll polyfill
+     * its own implementation. Normally this works fine, but its implementation is **different**
+     * than the one that `formdata-node` ships and when we use the `formdata-node` one under Node
+     * 18 `type` options that we set into `File` instances don't get picked up, resulting in
+     * multipart payloads being sent as `application/octet-stream` instead of whatever content type
+     * was attached to that file.
+     *
+     * This behavior also extends to Undici's usage of `Blob` as well where the `Blob` that ships
+     * with `formdata-node` behaves differently than the `Blob` that is part of the Node `buffer`
+     * module, which Undici wants you to use.
+     *
+     * `NODE_ENV` is set to `production` when Karma runs this code and we don't need to polyfill
+     * APIs that are already available in the browser.
+     */
+    if (process.env.NODE_ENV !== 'production') {
+      if (!globalThis.File) {
+        globalThis.FormData = require('formdata-node').FormData;
+      }
+
+      const isNode18 = (host.node as VersionInfo).version >= 18;
+      if (isNode18) {
+        globalThis.File = require('undici').File;
+        globalThis.Blob = require('buffer').Blob;
+      } else {
+        globalThis.File = require('formdata-node').File;
+        globalThis.Blob = require('formdata-node').Blob;
+      }
+    }
+
+    fetchHAR = require('../src').default;
+  });
+
   it('should throw if it looks like you are missing a valid HAR definition', function () {
-    expect(fetchHar).to.throw('Missing HAR definition');
-    expect(fetchHar.bind(null, { log: {} })).to.throw('Missing log.entries array');
-    expect(fetchHar.bind(null, { log: { entries: [] } })).to.throw('Missing log.entries array');
+    expect(fetchHAR).to.throw('Missing HAR definition');
+    expect(fetchHAR.bind(null, { log: {} })).to.throw('Missing log.entries array');
+    expect(fetchHAR.bind(null, { log: { entries: [] } })).to.throw('Missing log.entries array');
   });
 
   it('should make a request with a custom user agent if specified', async function () {
@@ -57,19 +61,19 @@ describe('#fetch', function () {
       this.skip();
     }
 
-    const res = await fetchHar(harExamples.short, { userAgent: 'test-app/1.0' }).then(r => r.json());
+    const res = await fetchHAR(harExamples.short, { userAgent: 'test-app/1.0' }).then(r => r.json());
     expect(res.headers['User-Agent']).to.equal('test-app/1.0');
   });
 
   it('should catch and toss invalid headers present in a HAR', async function () {
-    const res = await fetchHar(invalidHeadersHAR as Har).then(r => r.json());
+    const res = await fetchHAR(invalidHeadersHAR as Har).then(r => r.json());
     expect(res.headers['X-Api-Key']).to.equal('asdf1234');
     expect(res.headers['X-Api-Key (invalid)']).to.be.undefined;
   });
 
   describe('integrations', function () {
     it('should support `text/plain` requests', async function () {
-      const res = await fetchHar(harExamples['text-plain']).then(r => r.json());
+      const res = await fetchHAR(harExamples['text-plain']).then(r => r.json());
 
       expect(res.args).to.be.empty;
       expect(res.data).to.equal('Hello World');
@@ -82,14 +86,14 @@ describe('#fetch', function () {
     });
 
     it('should support requests with array query parameters', async function () {
-      const res = await fetchHar(harExamples.query).then(r => r.json());
+      const res = await fetchHAR(harExamples.query).then(r => r.json());
 
       expect(res.args).to.deep.equal({ baz: 'abc', foo: ['bar', 'baz'], key: 'value' });
       expect(res.url).to.equal('https://httpbin.org/get?key=value&foo=bar&foo=baz&baz=abc');
     });
 
     it('should not double encode query parameters', async function () {
-      const res = await fetchHar(harExamples['query-encoded']).then(r => r.json());
+      const res = await fetchHAR(harExamples['query-encoded']).then(r => r.json());
 
       expect(res.args).to.deep.equal({
         array: ['something&nothing=true', 'nothing&something=false', 'another item'],
@@ -105,7 +109,7 @@ describe('#fetch', function () {
     });
 
     it('should support requests with cookies', async function () {
-      const res = await fetchHar(harExamples.cookies).then(r => r.json());
+      const res = await fetchHAR(harExamples.cookies).then(r => r.json());
 
       if (host.browser) {
         // This assertion looks funky but because we're making a cross-origin request here we aren't going to have
@@ -123,7 +127,7 @@ describe('#fetch', function () {
     });
 
     it('should support `application/x-www-form-urlencoded` requests with auth', async function () {
-      const res = await fetchHar(urlEncodedWithAuthHAR as unknown as Har).then(r => r.json());
+      const res = await fetchHAR(urlEncodedWithAuthHAR as unknown as Har).then(r => r.json());
 
       expect(res.args).to.deep.equal({ a: '1', b: '2' });
       expect(res.data).to.equal('');
@@ -137,7 +141,7 @@ describe('#fetch', function () {
     });
 
     it('should support requests that cover the entire HAR spec', async function () {
-      const res = await fetchHar(harExamples.full).then(r => r.json());
+      const res = await fetchHAR(harExamples.full).then(r => r.json());
 
       expect(res.args).to.deep.equal({ baz: 'abc', foo: ['bar', 'baz'], key: 'value' });
       expect(res.data).to.equal('');
@@ -158,7 +162,7 @@ describe('#fetch', function () {
     describe('binary handling', function () {
       it('should support a `image/png` request', async function () {
         const har = harExamples['image-png'];
-        const res = await fetchHar(har).then(r => r.json());
+        const res = await fetchHAR(har).then(r => r.json());
 
         expect(res.args).to.be.empty;
         expect(res.data).to.equal(har.log.entries[0].request.postData.text);
@@ -174,14 +178,14 @@ describe('#fetch', function () {
     describe('multipart/form-data', function () {
       it('should throw an error if `fileName` is present without `value` or a mapping', function () {
         expect(() => {
-          fetchHar(harExamples['multipart-file']);
+          fetchHAR(harExamples['multipart-file']);
         }).to.throw(/doesn't have access to the filesystem/);
       });
 
       describe('`files` option', function () {
         it('should throw on an unsupported type', function () {
           expect(() => {
-            fetchHar(harExamples['multipart-data-dataurl'], {
+            fetchHAR(harExamples['multipart-data-dataurl'], {
               files: {
                 'owlbert.png': new Blob([owlbertDataURL], { type: 'image/png' }),
               },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -16,8 +16,11 @@ import { host } from '@jsdevtools/host-environment';
  * This behavior also extends to Undici's usage of `Blob` as well where the `Blob` that ships with
  * `formdata-node` behaves differently than the `Blob` that is part of the Node `buffer` module,
  * which Undici wants you to use.
+ *
+ * This code will only be loaded if we're running this test within a Node environment as `NODE_ENV`
+ * is set to `production` when we run tests through Karma.
  */
-if (host.node) {
+if (process.env.NODE_ENV !== 'production') {
   if (!globalThis.File) {
     globalThis.FormData = require('formdata-node').FormData;
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -71,6 +71,32 @@ describe('#fetch', function () {
     expect(res.headers['X-Api-Key (invalid)']).to.be.undefined;
   });
 
+  describe('custom options', function () {
+    it('should support supplying custom headers in a `Headers` instance', async function () {
+      const res = await fetchHAR(harExamples['text-plain'], {
+        init: {
+          headers: new Headers({
+            'x-custom-header': 'buster',
+          }),
+        },
+      }).then(r => r.json());
+
+      expect(res.headers['X-Custom-Header']).to.equal('buster');
+    });
+
+    it('should support supplying custom headers as an object', async function () {
+      const res = await fetchHAR(harExamples['text-plain'], {
+        init: {
+          headers: {
+            'x-custom-header': 'buster',
+          },
+        },
+      }).then(r => r.json());
+
+      expect(res.headers['X-Custom-Header']).to.equal('buster');
+    });
+  });
+
   describe('integrations', function () {
     it('should support `text/plain` requests', async function () {
       const res = await fetchHAR(harExamples['text-plain']).then(r => r.json());

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -4,6 +4,5 @@
     "noImplicitAny": false,
     "resolveJsonModule": true
   },
-  "include": ["../src/**/*", "*.ts", "**/*"],
-  // "exclude": ["__fixtures__/sdk/"]
+  "include": ["../src/**/*", "*.ts", "**/*"]
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noImplicitAny": false,
+    "resolveJsonModule": true
+  },
+  "include": ["../src/**/*", "*.ts", "**/*"],
+  // "exclude": ["__fixtures__/sdk/"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "baseUrl": "./src",
+    "declaration": true,
+    "esModuleInterop": true,
+    "lib": ["dom", "es2020"],
+    "noImplicitAny": true,
+    "outDir": "dist/"
+  },
+  "include": ["./src/**/*"]
+}


### PR DESCRIPTION
## 🧰 Changes

* [x] Rewrites the library in Typescript.
* [x] Adds test coverage for Node 18's native `fetch` implementation.
* [x] Drops the `constructRequest` export due to compatibility issues with [fetch-mock](https://npm.im/fetch-mock).
* [x] Adds a new `init` option to the library that allows you to supply custom [Request options](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request) (useful for custom headers, or `cache` settings).
  * Note that `credentials` and `body` will be overwritten by what's required by the HAR. `headers` will be appended to.

This is all obviously a breaking change and will require a new v8 release.

## 🐳  but why...

#### Why drop the `constructRequest` export?

This export normally works great! The problem we have now is that with the release of Node 18 libraries like [nock](https://npm.im/nock) don't support it so you're left to use [fetch-mock](https://npm.im/fetch-mock).

`fetch-mock` is a great library!... it just isn't able to mock `fetch` requests that are supplied a single `Request` instance. It expects all `fetch` requests to be either `fetch(url)` or `fetch(url, opts)`, and throws the following error on any mocked `fetch-har` request:

> fetch-mock: Unrecognised Request object. Read the Config and Installation sections of the docs

By dumping the `constructRequest` object we'll now always be composing `fetch` requests as `fetch(url, opts)`, which will be mockable under `fetch-mock`. Additionally, adding in this new `init` option will allow anyone (read: us) to move off `constructRequest` and to supply `fetch-har` directly the overrides we need.

#### Why rewrite the library in Typescript?

With this new `init` option being so dependent upon the settings you can supply to the [Request API](https://developer.mozilla.org/en-US/docs/Web/API/Request) it felt like the time was right to migrate this over.

#### Why do all this work for Node 18?

Node 18 was released to LTS status, and though its new native `fetch` implementation is considered experimental it's not hidden behind a flag (as one would expect). So we **have to** support it here, and in the upcoming [api](https://npm.im/api) v5 release.

## 🧬 QA & Testing

### Node tests

You can run either `npm run test` or `npm run test:only` (this'll skip `pretest` scripts). You can also run either of these on Node 14 or Node 16 or Node 18 and they'll all work. 😅

### Browser tests

You can run the browser tests for this thing by running `npm run test:browser`. Note that you'll need to accept the Open dialog that Safari as Puppeteer can't fully control Safari like it can other browsers. Also make sure that you're running this with Node 14, Karma crashes under Node 18.

https://user-images.githubusercontent.com/33762/165660819-0e1c5e04-bc17-4ffc-9d45-93e62d27fc6a.mov

### Testing the dist
To test the dist out locally run `npm run buld` and then `node example.js`.

#### Node 14
![Screen Shot 2022-04-27 at 12 39 17 PM](https://user-images.githubusercontent.com/33762/165611077-6ff1198b-57ae-46f8-85d4-0e9fe6452811.png)

#### Node 18
![Screen Shot 2022-04-27 at 12 38 45 PM](https://user-images.githubusercontent.com/33762/165611193-9d1454d6-bca4-4b31-be9e-51578ed1a938.png)