### PR TITLE
fix: swapping parse-data-url for @readme/data-urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "8.1.0",
       "license": "ISC",
       "dependencies": {
+        "@readme/data-urls": "^1.0.0",
         "@types/har-format": "^1.2.8",
-        "parse-data-url": "^4.0.1",
         "readable-stream": "^3.6.0"
       },
       "devDependencies": {
@@ -22,7 +22,6 @@
         "@types/mocha": "^9.1.1",
         "@types/multer": "^1.4.7",
         "@types/node": "^18.0.0",
-        "@types/parse-data-url": "^3.0.0",
         "@types/readable-stream": "^2.3.13",
         "chai": "^4.3.4",
         "datauri": "^4.1.0",
@@ -2230,6 +2229,14 @@
       "integrity": "sha512-D5H5RjqqE+YxI2oeTgSRuIjdy/hli90H5mMd81bBrYlOfB/f4TBsKMoaWfzI5E4bmFzLfQJuvvepTaWrxVfBug==",
       "dev": true
     },
+    "node_modules/@readme/data-urls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/data-urls/-/data-urls-1.0.0.tgz",
+      "integrity": "sha512-daQE56+udhu9TmvKeQ5O5gQDEJO/ZAx2KLFjZSczTmZTFk8rvAxSBrKY5LxeZ9DxaGxH+VDx2gvpN0BKLkYY+w==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@readme/eslint-config": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-9.0.0.tgz",
@@ -2526,15 +2533,6 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
-    },
-    "node_modules/@types/parse-data-url": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-data-url/-/parse-data-url-3.0.0.tgz",
-      "integrity": "sha512-W7j36KpA780hfh4jyQoLab3+uS+Svmug7GgdJoHe/4ak66ws6ar5/wD8Cqch01O+UT69pzfsBtpNzrF4/6ThBw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/puppeteer": {
       "version": "5.4.4",
@@ -12568,17 +12566,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "node_modules/parse-data-url": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/parse-data-url/-/parse-data-url-4.0.1.tgz",
-      "integrity": "sha512-W+ZgeHPkG2Awbj2RCGG3zALoKGoKucIWXRp8jPgTVNmRgiftXbwXXzzaXXH4L1+OdxeSXC6C8G+hzlcv41f24A==",
-      "dependencies": {
-        "valid-data-url": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -16065,14 +16052,6 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
-    "node_modules/valid-data-url": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-4.0.0.tgz",
-      "integrity": "sha512-mV5E0AG/F2yPiJzYlhyooI83BLIV0i4h/ueZwdxr1Mh8ZeKKpcFZLbZbAAedL/PLd11sqIgppJBrb4SNXA0PMQ==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -18707,6 +18686,11 @@
       "integrity": "sha512-D5H5RjqqE+YxI2oeTgSRuIjdy/hli90H5mMd81bBrYlOfB/f4TBsKMoaWfzI5E4bmFzLfQJuvvepTaWrxVfBug==",
       "dev": true
     },
+    "@readme/data-urls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/data-urls/-/data-urls-1.0.0.tgz",
+      "integrity": "sha512-daQE56+udhu9TmvKeQ5O5gQDEJO/ZAx2KLFjZSczTmZTFk8rvAxSBrKY5LxeZ9DxaGxH+VDx2gvpN0BKLkYY+w=="
+    },
     "@readme/eslint-config": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-9.0.0.tgz",
@@ -18974,15 +18958,6 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
-    },
-    "@types/parse-data-url": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-data-url/-/parse-data-url-3.0.0.tgz",
-      "integrity": "sha512-W7j36KpA780hfh4jyQoLab3+uS+Svmug7GgdJoHe/4ak66ws6ar5/wD8Cqch01O+UT69pzfsBtpNzrF4/6ThBw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/puppeteer": {
       "version": "5.4.4",
@@ -26903,14 +26878,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "parse-data-url": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/parse-data-url/-/parse-data-url-4.0.1.tgz",
-      "integrity": "sha512-W+ZgeHPkG2Awbj2RCGG3zALoKGoKucIWXRp8jPgTVNmRgiftXbwXXzzaXXH4L1+OdxeSXC6C8G+hzlcv41f24A==",
-      "requires": {
-        "valid-data-url": "^4.0.0"
-      }
-    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -29708,11 +29675,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
-    },
-    "valid-data-url": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-4.0.0.tgz",
-      "integrity": "sha512-mV5E0AG/F2yPiJzYlhyooI83BLIV0i4h/ueZwdxr1Mh8ZeKKpcFZLbZbAAedL/PLd11sqIgppJBrb4SNXA0PMQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/readmeio/fetch-har#readme",
   "dependencies": {
+    "@readme/data-urls": "^1.0.0",
     "@types/har-format": "^1.2.8",
-    "parse-data-url": "^4.0.1",
     "readable-stream": "^3.6.0"
   },
   "optionalDependencies": {
@@ -46,7 +46,6 @@
     "@types/mocha": "^9.1.1",
     "@types/multer": "^1.4.7",
     "@types/node": "^18.0.0",
-    "@types/parse-data-url": "^3.0.0",
     "@types/readable-stream": "^2.3.13",
     "chai": "^4.3.4",
     "datauri": "^4.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { Har } from 'har-format';
+import type { DataURL as npmDataURL } from '@readme/data-urls';
 import { Readable } from 'readable-stream';
-import parseDataUrl from 'parse-data-url';
+import { parse as parseDataUrl } from '@readme/data-urls';
 
 if (!globalThis.Blob) {
   try {
@@ -92,7 +93,7 @@ type FetchHAROptions = {
   init?: RequestInit;
 };
 
-type DataURL = parseDataUrl.DataUrl & {
+type DataURL = npmDataURL & {
   // `parse-data-url` doesn't explicitly support `name` in data URLs but if it's there it'll be
   // returned back to us.
   name?: string;


### PR DESCRIPTION
| 🚥 Fix RM-3195 |
| :-- |

## 🧰 Changes

There's a bug in [valid-data-url](https://npm.im/valid-data-url) where it doesn't recognize data URLs that have underscores as being valid. They are!

I've submitted a fix upstream but in the meantime instead of waiting for that to be merged, published, and then merged into [parse-data-url](https://npm.im/parse-data-url), and published, I've soft forked both libraries and merged them into [@readme/data-urls](https://npm.im/@readme/data-urls).
