### PR TITLE
fix: support urls with hashes that also have query params

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -413,12 +413,12 @@ export default function fetchHAR(har: Har, opts: FetchHAROptions = {}) {
 
     // Because anchor hashes before query strings will prevent query strings from being delivered
     // we need to pop them off and re-add them after.
-    const urlHashes = url.split('#');
-    requestURL = `${urlHashes[0].split('?')[0]}${querystring ? `?${querystring}` : ''}`;
-    if (urlHashes.length > 1) {
-      // Though web servers don't have access to hashes we might as well send it anyways as it
-      // was intentionally added to the URL.
-      requestURL += `#${urlHashes.join('#')}`;
+    if (urlObj.hash) {
+      const urlWithoutHashes = requestURL.replace(urlObj.hash, '');
+      requestURL = `${urlWithoutHashes.split('?')[0]}${querystring ? `?${querystring}` : ''}`;
+      requestURL += urlObj.hash;
+    } else {
+      requestURL = `${requestURL.split('?')[0]}${querystring ? `?${querystring}` : ''}`;
     }
   }
 

--- a/test/file-upload-quirks.test.ts
+++ b/test/file-upload-quirks.test.ts
@@ -23,7 +23,6 @@ describe('#fetchHAR (Node-only quirks)', function () {
   let fetchHAR;
   let app: Express;
   let listener;
-  let initOptions: RequestInit = {};
 
   beforeEach(async function () {
     /**
@@ -41,17 +40,9 @@ describe('#fetchHAR (Node-only quirks)', function () {
     if (hasNativeFetch) {
       globalThis.File = require('undici').File;
       globalThis.Blob = require('buffer').Blob;
-
-      initOptions = {
-        // https://github.com/nodejs/node/issues/46221
-        // @ts-expect-error `duplex` is part of the Fetch standard, and is wanted by `undici`, but is not yet in the `RequestInit` types.
-        duplex: 'half',
-      };
     } else {
       globalThis.File = require('formdata-node').File;
       globalThis.Blob = require('formdata-node').Blob;
-
-      initOptions = {};
 
       // We only need to polyfill handlers for `multipart/form-data` requests below Node 18 as Node
       // 18 natively supports `fetch`.
@@ -94,7 +85,6 @@ describe('#fetchHAR (Node-only quirks)', function () {
         'owlbert.png': await fs.readFile(`${__dirname}/fixtures/owlbert.png`),
         'owlbert-shrub.png': await fs.readFile(`${__dirname}/fixtures/owlbert-shrub.png`),
       },
-      init: initOptions,
       multipartEncoder: FormDataEncoder,
     }).then(r => r.json());
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -294,7 +294,7 @@ describe('fetch-har', function () {
 
         const res = await fetchHAR(har).then(r => {
           // This URL with the hash will only be present here as HTTPBin's web server doesn't
-          // support seeing hashes in incoming URLs
+          // support seeing hashes in incoming URLs.
           expect(r.url).to.equal('https://httpbin.org/anything?dog=true&dog_id=buster18#anything');
           return r.json();
         });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -284,7 +284,7 @@ describe('fetch-har', function () {
                   },
                   bodySize: 0,
                   method: 'GET',
-                  url: 'https://httpbin.org/anything#anything',
+                  url: 'https://httpbin.org/anything?dog=true#anything',
                   httpVersion: 'HTTP/1.1',
                 },
               },
@@ -292,11 +292,15 @@ describe('fetch-har', function () {
           },
         };
 
-        const res = await fetchHAR(har).then(r => r.json());
+        const res = await fetchHAR(har).then(r => {
+          // This URL with the hash will only be present here as HTTPBin's web server doesn't
+          // support seeing hashes in incoming URLs
+          expect(r.url).to.equal('https://httpbin.org/anything?dog=true&dog_id=buster18#anything');
+          return r.json();
+        });
 
-        expect(res.args).to.deep.equal({ dog_id: 'buster18' });
-        // `#anything` isn't a part of this URL because web servers don't have access to hashes.
-        expect(res.url).to.equal('https://httpbin.org/anything?dog_id=buster18');
+        expect(res.args).to.deep.equal({ dog: 'true', dog_id: 'buster18' });
+        expect(res.url).to.equal('https://httpbin.org/anything?dog=true&dog_id=buster18');
       });
     });
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -293,17 +293,7 @@ describe('fetch-har', function () {
           },
         };
 
-        const res = await fetchHAR(har).then(r => {
-          // This URL with the hash will only be present here as HTTPBin's web server doesn't
-          // support seeing hashes in incoming URLs.
-          if (hasNativeFetch) {
-            // `undici` in Node 18+ doesn't return the URL here with the hash.
-            expect(r.url).to.equal('https://httpbin.org/anything?dog=true&dog_id=buster18');
-          } else {
-            expect(r.url).to.equal('https://httpbin.org/anything?dog=true&dog_id=buster18#anything');
-          }
-          return r.json();
-        });
+        const res = await fetchHAR(har).then(r => r.json());
 
         expect(res.args).to.deep.equal({ dog: 'true', dog_id: 'buster18' });
         expect(res.url).to.equal('https://httpbin.org/anything?dog=true&dog_id=buster18');

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -257,6 +257,47 @@ describe('fetch-har', function () {
           fetchHAR(har);
         }).not.to.throw("Cannot read property 'length' of undefined");
       });
+
+      it('should support urls with query parameters if the url has an anchor hash in it', async function () {
+        const har = {
+          log: {
+            entries: [
+              {
+                request: {
+                  cookies: [],
+                  headers: [
+                    {
+                      name: 'content-type',
+                      value: 'multipart/form-data',
+                    },
+                  ],
+                  headersSize: 0,
+                  queryString: [
+                    {
+                      name: 'dog_id',
+                      value: 'buster18',
+                    },
+                  ],
+                  postData: {
+                    mimeType: 'application/json',
+                    text: undefined,
+                  },
+                  bodySize: 0,
+                  method: 'GET',
+                  url: 'https://httpbin.org/anything#anything',
+                  httpVersion: 'HTTP/1.1',
+                },
+              },
+            ],
+          },
+        };
+
+        const res = await fetchHAR(har).then(r => r.json());
+
+        expect(res.args).to.deep.equal({ dog_id: 'buster18' });
+        // `#anything` isn't a part of this URL because web servers don't have access to hashes.
+        expect(res.url).to.equal('https://httpbin.org/anything?dog_id=buster18');
+      });
     });
   });
 });


### PR DESCRIPTION
## 🧰 Changes

This fixes a bug in our query parameter handling where if an incoming URL had a hash in it (`https://httpbin.org/anything#anything`) that **also** had query parameters we would append those query params **after** the hash, resulting in the processing web server not seeing that query parameters are present as the hash must be the last part of the URL.

I also cleaned up some of the funky Node 18 quirks for `RequestInit#duplex` I fixed in https://github.com/readmeio/fetch-har/pull/362 to bring it core into the library so implementers (like [api](https://npm.im/api) don't need to handle it themselves.