### PR TITLE
fix: convert library to module

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": ["@readme/eslint-config", "@readme/eslint-config/typescript"],
+  "extends": ["@readme/eslint-config", "@readme/eslint-config/typescript", "@readme/eslint-config/esm"],
   "root": true,
   "env": {
     "es2020": true
@@ -7,8 +7,7 @@
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "global-require": "off",
-    "no-case-declarations": "off",
-    "unicorn/prefer-node-protocol": "error"
+    "no-case-declarations": "off"
   },
   "overrides": [
     {

--- a/example.mjs
+++ b/example.mjs
@@ -1,4 +1,4 @@
-import fetchHAR from './dist/index.mjs';
+import fetchHAR from './dist/index.js';
 
 const har = {
   log: {

--- a/package.json
+++ b/package.json
@@ -2,18 +2,19 @@
   "name": "fetch-har",
   "version": "11.0.0",
   "description": "Make a fetch request from a HAR definition",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
+  "main": "dist/index.cjs",
+  "types": "dist/index.d.cts",
+  "module": "dist/index.js",
+  "type": "module",
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     },
     "./types": {
-      "import": "./dist/types.mjs",
-      "require": "./dist/types.js"
+      "import": "./dist/types.js",
+      "require": "./dist/types.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ function getFileFromSuppliedFiles(filename: string, files: FetchHAROptions['file
   return false;
 }
 
-export default function fetchHAR(har: Har, opts: FetchHAROptions = {}) {
+export default function fetchHAR(har: Har, opts: FetchHAROptions = {}): Promise<Response> {
   if (!har) throw new Error('Missing HAR definition');
   if (!har.log || !har.log.entries || !har.log.entries.length) throw new Error('Missing log.entries array');
 

--- a/test/browser-quirks.test.ts
+++ b/test/browser-quirks.test.ts
@@ -2,7 +2,7 @@ import { host } from '@jsdevtools/host-environment';
 import harExamples from 'har-examples';
 import { describe, it, expect } from 'vitest';
 
-import fetchHAR from '../src';
+import fetchHAR from '../src/index.js';
 
 import owlbertShrubDataURL from './fixtures/owlbert-shrub.dataurl.json';
 import owlbert from './fixtures/owlbert.dataurl.json';

--- a/test/file-upload-quirks.test.ts
+++ b/test/file-upload-quirks.test.ts
@@ -9,7 +9,7 @@ import multer from 'multer';
 import tempDirectory from 'temp-dir';
 import { describe, beforeEach, afterEach, it, expect } from 'vitest';
 
-import fetchHAR from '../src';
+import fetchHAR from '../src/index.js';
 
 import arrayOfOwlbertsHAR from './fixtures/array-of-owlberts.har.json';
 import owlbertShrubDataURL from './fixtures/owlbert-shrub.dataurl.json';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -12,11 +12,11 @@ import urlEncodedWithAuthHAR from './fixtures/urlencoded-with-auth.har.json';
 
 describe('fetch-har', () => {
   it('should throw if it looks like you are missing a valid HAR definition', () => {
-    expect(fetchHAR).toThrow('Missing HAR definition');
+    expect(fetchHAR).rejects.toThrow('Missing HAR definition');
     // @ts-expect-error deliberately bad data
-    expect(fetchHAR.bind(null, { log: {} })).toThrow('Missing log.entries array');
+    expect(fetchHAR.bind(null, { log: {} })).rejects.toThrow('Missing log.entries array');
     // @ts-expect-error deliberately bad data
-    expect(fetchHAR.bind(null, { log: { entries: [] } })).toThrow('Missing log.entries array');
+    expect(fetchHAR.bind(null, { log: { entries: [] } })).rejects.toThrow('Missing log.entries array');
   });
 
   // eslint-disable-next-line vitest/require-hook
@@ -169,20 +169,18 @@ describe('fetch-har', () => {
 
     describe('multipart/form-data', () => {
       it('should throw an error if `fileName` is present without `value` or a mapping', () => {
-        expect(() => {
-          fetchHAR(harExamples['multipart-file']);
-        }).toThrow(/doesn't have access to the filesystem/);
+        expect(fetchHAR(harExamples['multipart-file'])).rejects.toThrow(/doesn't have access to the filesystem/);
       });
 
       describe('`files` option', () => {
         it('should throw on an unsupported type', () => {
-          expect(() => {
+          expect(
             fetchHAR(harExamples['multipart-data-dataurl'], {
               files: {
                 'owlbert.png': new Blob([owlbertDataURL], { type: 'image/png' }),
               },
-            });
-          }).toThrow('An unknown object has been supplied into the `files` config for use.');
+            }),
+          ).rejects.toThrow('An unknown object has been supplied into the `files` config for use.');
         });
       });
     });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,7 +4,7 @@ import { host } from '@jsdevtools/host-environment';
 import harExamples from 'har-examples';
 import { describe, it, expect } from 'vitest';
 
-import fetchHAR from '../src';
+import fetchHAR from '../src/index.js';
 
 import invalidHeadersHAR from './fixtures/invalid-headers.har.json';
 import owlbertDataURL from './fixtures/owlbert.dataurl.json';

--- a/test/mocking/fetch-mock.test.ts
+++ b/test/mocking/fetch-mock.test.ts
@@ -2,7 +2,7 @@ import fetchMock from 'fetch-mock';
 import harExamples from 'har-examples';
 import { describe, it, expect } from 'vitest';
 
-import fetchHAR from '../../src';
+import fetchHAR from '../../src/index.js';
 
 describe('#fetchHAR mocking (fetch-mock)', () => {
   it('should support mocking a request with `fetch-mock`', async () => {

--- a/test/mocking/msw.test.ts
+++ b/test/mocking/msw.test.ts
@@ -3,7 +3,7 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { describe, it, expect } from 'vitest';
 
-import fetchHAR from '../../src';
+import fetchHAR from '../../src/index.js';
 
 describe('#fetchHAR mocking (msw)', () => {
   it('should support mocking a request with `msw`', async () => {

--- a/test/node-quirks.test.ts
+++ b/test/node-quirks.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import harExamples from 'har-examples';
 import { describe, it, expect } from 'vitest';
 
-import fetchHAR from '../src';
+import fetchHAR from '../src/index.js';
 
 import owlbertScreenshotDataURL from './fixtures/owlbert-screenshot.dataurl.json';
 import owlbertShrubDataURL from './fixtures/owlbert-shrub.dataurl.json';


### PR DESCRIPTION
## 🧰 Changes

Turns out that I got so lost in the sauce in #427 that [this commit](https://github.com/readmeio/fetch-har/pull/427/commits/8bd0f21daf2fdbd20bd2302f820220f92c7a7a3d) ended up breaking things for the Node ESM usage 😭 I for some reason assumed that `tsup` properly transpiles the `require` statements but evidently not...

Here's the stack trace of the error you see when running `node example.mjs` on the `main` branch:

```
Error: Dynamic require of "undici" is not supported
    at file:///Users/kanadg/Code/readmeio/fetch-har/dist/index.mjs:25:9
    at file:///Users/kanadg/Code/readmeio/fetch-har/dist/index.mjs:39:23
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25)
file:///Users/kanadg/Code/readmeio/fetch-har/dist/index.mjs:42
    throw new Error("The File API is required for this library. https://developer.mozilla.org/en-US/docs/Web/API/File");
```



The main function is now async since we're doing dynamic imports, but it has always returned a `Promise<Response>` so I _think_ this should be a patch change?

## 🧬 QA & Testing

Check out this branch and try running the following commands to ensure they succeed:

```sh
# install + build
npm ci && npm run build

# run example scripts
node example.mjs
node example.cjs
deno run -A example.mjs
bun example.mjs
bun example.cjs
```
