### PR TITLE
feat: remove our dependency on `undici`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@readme/data-urls": "^3.0.0",
-        "@types/har-format": "^1.2.13",
-        "undici": "^5.25.1"
+        "@types/har-format": "^1.2.13"
       },
       "devDependencies": {
         "@jsdevtools/host-environment": "^2.1.2",
@@ -36,7 +35,7 @@
         "webdriverio": "^8.16.15"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.13.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -981,14 +980,6 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -11140,17 +11131,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/undici": {
-      "version": "5.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.0.tgz",
-      "integrity": "sha512-l3ydWhlhOJzMVOYkymLykcRRXqbUaQriERtR70B9LzNkZ4bX52Fc8wbTDneMiwo8T+AemZXvXaTx+9o5ROxrXg==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "./package.json": "./package.json"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18.13.0"
   },
   "files": [
     "dist"
@@ -47,8 +47,7 @@
   "homepage": "https://github.com/readmeio/fetch-har#readme",
   "dependencies": {
     "@readme/data-urls": "^3.0.0",
-    "@types/har-format": "^1.2.13",
-    "undici": "^5.25.1"
+    "@types/har-format": "^1.2.13"
   },
   "devDependencies": {
     "@jsdevtools/host-environment": "^2.1.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,11 +60,9 @@ export default async function fetchHAR(har: Har, opts: FetchHAROptions = {}): Pr
 
   if (!globalThis.File) {
     try {
-      // Node's native `fetch` implementation unfortunately does not make this API global so we need
-      // to pull it in if we don't have it.
-      const UndiciFile = (await import('undici')).File;
+      const NodeFile = (await import('node:buffer')).File;
       // @ts-expect-error the types don't match exactly, which is expected!
-      globalThis.File = UndiciFile;
+      globalThis.File = NodeFile;
     } catch (e) {
       throw new Error(
         'The File API is required for this library. https://developer.mozilla.org/en-US/docs/Web/API/File',


### PR DESCRIPTION
## 🧰 Changes

While pulling our latest release of this library into our main app I was having a lot of problems with Webpack trying to compile in `undici` into our frontend code because of the logic we've got here if the [File API](https://developer.mozilla.org/en-US/docs/Web/API/File) isn't present. Well much to my surprise Node began exposing this back in 18.13.0[^1].

By removing `undici` completely and using `File` in `node:buffer` folks who use Webpack (especially `api` users) will be able to add a fallback for it[^2]:

```js
resolve: {
  fallback: {
    buffer: require.resolve('buffer/')
  }
}
```

Though this requires pinning our minimum Node 18 release at 18.13.0 instead of just 18.* I'm iffy on considering this a breaking change because Node 18.13.0 was released by in January and everyone, including us, who are using 18 should be past it by now. We may want to also pin `@readme/api-core` and `api` to `>=18.13.0` though because they, well at least `api-core`, use this library.

[^1]: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2023-01-05-version-18130-hydrogen-lts-danielleadams
[^2]: Something they've likely already had to do for the `Blob` polyfill we are using out of it if `global.Blob` isn't present.
