### PR TITLE
fix: send raw binary for encoded data URL filenames

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -250,7 +250,7 @@ export default async function fetchHAR(har: Har, opts: FetchHAROptions = {}): Pr
       if (opts.files) {
         const parsed = parseDataUrl(request.postData.text) as DataURL;
         if (parsed) {
-          if (parsed?.name && parsed.name in opts.files) {
+          if (parsed?.name) {
             const fileContents = getFileFromSuppliedFiles(parsed.name, opts.files);
             if (fileContents) {
               if (isBuffer(fileContents)) {

--- a/test/node-quirks.test.ts
+++ b/test/node-quirks.test.ts
@@ -48,6 +48,31 @@ describe('#fetchHAR (Node-only quirks)', () => {
         expect(res.url).toBe('https://httpbin.org/post');
       });
 
+      it('should support a Buffer `files` mapping override for a raw payload data URL with an encoded file name', async () => {
+        const filename = 'owlbert screen shot.png';
+        const encodedFilename = encodeURIComponent(filename);
+        const har = JSON.parse(JSON.stringify(harExamples['image-png']));
+        har.log.entries[0].request.postData.text = har.log.entries[0].request.postData.text.replace(
+          'name=owlbert.png',
+          `name=${encodedFilename}`,
+        );
+        const originalDataUrlPayload = har.log.entries[0].request.postData.text;
+
+        const owlbert = await fs.readFile(`${__dirname}/fixtures/owlbert.png`);
+        const res = await fetchHAR(har, { files: { [filename]: owlbert } }).then(r => r.json());
+
+        expect(res.args).toStrictEqual({});
+        expect(res.data).not.toBe(originalDataUrlPayload);
+        expect(res.data).not.toContain(`name=${encodedFilename}`);
+        expect(res.data).toMatch(/^data:application\/octet-stream;base64,/);
+        expect(res.files).toStrictEqual({});
+        expect(res.form).toStrictEqual({});
+        expect(parseInt(res.headers['Content-Length'], 10)).toBe(400);
+        expect(res.headers['Content-Type']).toBe('image/png');
+        expect(res.json).toBeNull();
+        expect(res.url).toBe('https://httpbin.org/post');
+      });
+
       it('should support a File `files` mapping override for a raw payload data URL', async () => {
         // In the HAR is `owlbert.png` but we want to adhoc override that with the contents of
         // `owlbert-shrub.png` here to ensure that the override works.


### PR DESCRIPTION
| 🚥 Resolves RM-5000 |
| :------------------- |

## 🧰 Changes

Fixes raw binary uploads when a data URL contains an encoded filename, such as `owlbert%20screen%20shot.png`.

Previously, the raw `postData.text` path checked `parsed.name` in `opts.files` before calling `getFileFromSuppliedFiles()`. That skipped the helper’s decoded-filename fallback, so encoded data URL names could fail to match decoded files keys. When that happened, `fetch-har` sent the original base64 data URL string instead of the supplied raw file bytes.

This PR removes that strict pre-check and lets `getFileFromSuppliedFiles()` handle both encoded and decoded filename matching.

## 🧬 QA & Testing

Added a regression test for a raw `image/png` payload where the HAR data URL contains an encoded filename with spaces, while the supplied files map uses the decoded filename.

<img width="1112" height="591" alt="image" src="https://github.com/user-attachments/assets/2e527f73-5bfe-40d9-8ac2-cf671de62786" />